### PR TITLE
fix: GitHub Actions の失敗を修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,20 +2,10 @@ version: 2
 updates:
   - package-ecosystem: "bundler"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "master"
     schedule:
       interval: "weekly"
       day: "friday"
       time: "00:32"
       timezone: "Asia/Tokyo"
-    versioning-strategy: "lockfile-only"
-    open-pull-requests-limit: 2
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "friday"
-      time: "00:32"
-      timezone: "Asia/Tokyo"
-    versioning-strategy: "lockfile-only"
     open-pull-requests-limit: 2

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.3'
+          ruby-version: '3.3'
           bundler-cache: true
       
       - name: Setup Pages

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ _site
 .bundle
 .sass-cache
 Gemfile
-Gemfile.lock
 node_modules
 package.json
 test.py

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source "https://rubygems.org"
 gem "csv"
 gem "bigdecimal"
 
-# GitHub Pages用のJekyll設定
-gem "github-pages", group: :jekyll_plugins
+# Jekyll 4.x (github-pages gemはJekyll 3.9.0に固定されており、Ruby 4.x非対応のため置き換え)
+gem "jekyll", "~> 4.3"
 
 # プラグイン
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,81 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    bigdecimal (4.1.2)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.6)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.4)
+    forwardable-extended (2.6.0)
+    google-protobuf (3.23.4)
+    http_parser.rb (0.8.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.3.4)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (>= 0.3.6, < 0.5)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
+    jekyll-seo-tag (2.9.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (5.1.1)
+    rake (13.4.2)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (3.30.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.58.3)
+      google-protobuf (~> 3.21)
+      rake (>= 10.0.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bigdecimal
+  csv
+  jekyll (~> 4.3)
+  jekyll-seo-tag
+
+BUNDLED WITH
+   1.17.2


### PR DESCRIPTION
## 概要

GitHub Actions で発生していた3種類の失敗を修正します。

## 修正内容

### 🔴 Jekyll デプロイの失敗（最重要）

**原因**: `github-pages` gem が依存する `liquid 4.0.3` が、Ruby 3.2+ で削除された `tainted?` メソッドを使用しており、Ruby 4.0.3 環境でクラッシュ

**対処**:
- `Gemfile`: `github-pages` gem を `jekyll ~> 4.3` に置き換え
- `jekyll.yml`: Ruby バージョンを `4.0.3` → `3.3` に変更
- `Gemfile.lock` を追加し、`.gitignore` から除外

### 🟡 Dependabot npm_and_yarn の失敗

**原因**: `package.json` が存在しないのに `npm` エコシステムが設定されていた

**対処**: `dependabot.yml` から npm セクションを削除

### 🟡 Dependabot bundler の失敗

**原因**: `target-branch: develop` が指定されていたが、develop ブランチに Gemfile が存在しない

**対処**: `target-branch` を `master` に変更

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `Gemfile` | `github-pages` → `jekyll ~> 4.3` |
| `Gemfile.lock` | 新規追加 |
| `.github/workflows/jekyll.yml` | Ruby `4.0.3` → `3.3` |
| `.github/dependabot.yml` | npm 削除、target-branch を master に修正 |
| `.gitignore` | Gemfile.lock を除外対象から削除 |