### PR TITLE
Improve SEO metadata

### DIFF
--- a/astro/public/robots.txt
+++ b/astro/public/robots.txt
@@ -1,1 +1,4 @@
+User-agent: *
+Allow: /
+
 Sitemap: https://www.peipeipe.net/sitemap-index.xml

--- a/astro/src/layouts/BaseLayout.astro
+++ b/astro/src/layouts/BaseLayout.astro
@@ -7,15 +7,58 @@ interface Props {
   canonicalPath?: string;
   wide?: boolean;
   robots?: string;
+  type?: "website" | "article";
+  image?: string;
+  publishedTime?: Date | string;
+  modifiedTime?: Date | string;
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
 const siteName = "peipeipe.net";
 const siteDescription = "読んだ本とやったこと";
 const siteUrl = "https://www.peipeipe.net";
 const avatar = "/images/avatar.png";
-const { title, description = siteDescription, canonicalPath = Astro.url.pathname, wide = false, robots } = Astro.props;
+const {
+  title,
+  description = siteDescription,
+  canonicalPath = Astro.url.pathname,
+  wide = false,
+  robots,
+  type = "website",
+  image = avatar,
+  publishedTime,
+  modifiedTime,
+  jsonLd,
+} = Astro.props;
 const pageTitle = title ? `${title} - ${siteName} - ${siteDescription}` : `${siteName} - ${siteDescription}`;
 const canonicalUrl = new URL(canonicalPath, siteUrl).toString();
+const imageUrl = new URL(image, siteUrl).toString();
+const toIsoString = (value?: Date | string) => {
+  if (!value) return undefined;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+};
+const publishedTimeIso = toIsoString(publishedTime);
+const modifiedTimeIso = toIsoString(modifiedTime);
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: siteName,
+  url: siteUrl,
+  description: siteDescription,
+  inLanguage: "ja",
+  publisher: {
+    "@type": "Person",
+    name: "peipeipe",
+    url: siteUrl,
+  },
+  potentialAction: {
+    "@type": "SearchAction",
+    target: `${siteUrl}/search/?q={search_term_string}`,
+    "query-input": "required name=search_term_string",
+  },
+};
+const structuredData = [websiteJsonLd, ...(Array.isArray(jsonLd) ? jsonLd : jsonLd ? [jsonLd] : [])];
 ---
 
 <!doctype html>
@@ -32,17 +75,25 @@ const canonicalUrl = new URL(canonicalPath, siteUrl).toString();
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{pageTitle}</title>
     <meta name="description" content={description} />
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@peipeipe" />
+    <meta name="twitter:title" content={pageTitle} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={imageUrl} />
     <meta property="og:site_name" content={siteName} />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={type} />
     <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:image" content={imageUrl} />
+    <meta property="og:locale" content="ja_JP" />
+    {publishedTimeIso && <meta property="article:published_time" content={publishedTimeIso} />}
+    {modifiedTimeIso && <meta property="article:modified_time" content={modifiedTimeIso} />}
     {robots && <meta name="robots" content={robots} />}
     <link rel="me" href="https://mstdn.jp/@peipeipe" />
     <link rel="canonical" href={canonicalUrl} />
     <link rel="alternate" type="application/rss+xml" title={`${siteName} - ${siteDescription}`} href="/feed.xml" />
+    <script type="application/ld+json" set:html={JSON.stringify(structuredData).replace(/</g, "\\u003c")} />
     <slot name="head" />
   </head>
   <body>

--- a/astro/src/pages/[...slug].astro
+++ b/astro/src/pages/[...slug].astro
@@ -20,9 +20,39 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props;
+const postUrl = new URL(post.url, "https://www.peipeipe.net").toString();
+const postJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  headline: post.title,
+  description: post.excerpt,
+  datePublished: post.date.toISOString(),
+  dateModified: post.date.toISOString(),
+  mainEntityOfPage: postUrl,
+  url: postUrl,
+  inLanguage: "ja",
+  author: {
+    "@type": "Person",
+    name: "peipeipe",
+    url: "https://www.peipeipe.net/about",
+  },
+  publisher: {
+    "@type": "Person",
+    name: "peipeipe",
+    url: "https://www.peipeipe.net",
+  },
+};
 ---
 
-<BaseLayout title={post.title}>
+<BaseLayout
+  title={post.title}
+  description={post.excerpt}
+  canonicalPath={post.url}
+  type="article"
+  publishedTime={post.date}
+  modifiedTime={post.date}
+  jsonLd={postJsonLd}
+>
   <article class="post">
     <h1>{post.title}</h1>
     <div set:html={post.html} />

--- a/astro/src/pages/diary/[date].astro
+++ b/astro/src/pages/diary/[date].astro
@@ -12,9 +12,39 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const diaryDate = entry.title;
+const entryUrl = new URL(entry.url, "https://www.peipeipe.net").toString();
+const diaryJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  headline: entry.title,
+  description: entry.excerpt,
+  datePublished: entry.date.toISOString(),
+  dateModified: entry.date.toISOString(),
+  mainEntityOfPage: entryUrl,
+  url: entryUrl,
+  inLanguage: "ja",
+  author: {
+    "@type": "Person",
+    name: "peipeipe",
+    url: "https://www.peipeipe.net/about",
+  },
+  publisher: {
+    "@type": "Person",
+    name: "peipeipe",
+    url: "https://www.peipeipe.net",
+  },
+};
 ---
 
-<BaseLayout title={entry.title}>
+<BaseLayout
+  title={entry.title}
+  description={entry.excerpt}
+  canonicalPath={entry.url}
+  type="article"
+  publishedTime={entry.date}
+  modifiedTime={entry.date}
+  jsonLd={diaryJsonLd}
+>
   <article class="diary-entry">
     <header class="diary-header">
       <h1 class="diary-date">{diaryDate}</h1>


### PR DESCRIPTION
### Motivation

- Provide better SEO and social sharing metadata site-wide so pages render with rich previews and search engines understand site structure.
- Surface article-specific metadata (canonical, published/modified times, description, JSON-LD) for blog posts and diary entries to improve indexability and rich results.
- Explicitly allow crawling in `robots.txt` while keeping the existing sitemap reference.

### Description

- Extend `astro/src/layouts/BaseLayout.astro` to accept `type`, `image`, `publishedTime`, `modifiedTime`, and `jsonLd` props and emit richer Open Graph and Twitter Card tags, locale, and article timestamps. 
- Add a `WebSite` JSON-LD block (including a `SearchAction`) to `BaseLayout` and render any passed `jsonLd` as structured data. 
- Add `BlogPosting` JSON-LD, canonical path, description, and article meta wiring to `astro/src/pages/[...slug].astro` for posts. 
- Add `BlogPosting` JSON-LD, canonical path, description, and article meta wiring to `astro/src/pages/diary/[date].astro` for diary entries, and update `astro/public/robots.txt` to explicitly `Allow: /` while preserving the sitemap link.

### Testing

- Ran site build with Node `22.22.2` via `cd astro && source /root/.nvm/nvm.sh && nvm use 22.22.2 >/dev/null && npm run build` and the build completed successfully. 
- Ran URL manifest and legacy slug check with `npm run manifest` and `npm run check:legacy-slugs` and both completed with expected outputs (manifest created and `Found 0 legacy invalid percent slug(s)`). 
- No visual changes were required, as changes are metadata-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f9a8d5ea0832b9e9bb64a4de0d428)