### PR TITLE
Assert rendered content in the build check

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -63,6 +63,49 @@ jobs:
           test -d dist/images
           npm run check:legacy-slugs
 
+      - name: Verify rendered content
+        run: |
+          # The build can succeed while silently producing empty or malformed
+          # pages (a Markdown or card-rendering regression). Assert that each
+          # kind of content actually made it into dist/. Thresholds sit well
+          # below current counts so ordinary content changes do not trip them.
+          fail=0
+
+          assert_pages() {
+            local marker="$1" min="$2" actual
+            actual=$(grep -rl --include=index.html -e "$marker" dist | wc -l)
+            if [ "$actual" -lt "$min" ]; then
+              echo "::error::'$marker' on $actual page(s), expected at least $min"
+              fail=1
+            fi
+          }
+
+          assert_count() {
+            local marker="$1" file="$2" min="$3" actual
+            actual=$(grep -o -e "$marker" "$file" | wc -l)
+            if [ "$actual" -lt "$min" ]; then
+              echo "::error::'$marker' appears $actual time(s) in $file, expected at least $min"
+              fail=1
+            fi
+          }
+
+          pages=$(find dist -name index.html | wc -l)
+          if [ "$pages" -lt 400 ]; then
+            echo "::error::built $pages page(s), expected at least 400"
+            fail=1
+          fi
+
+          assert_pages '<article class="post"' 300
+          assert_pages '<article class="diary-entry"' 40
+          assert_pages 'krb-amzlt-box' 120
+          assert_pages 'class="link-card"' 3
+
+          assert_count '<article class="checkin-item"' dist/onsen/index.html 40
+          assert_count '<article class="mountain-item"' dist/mountains/index.html 30
+          assert_count '<article class="activity-item"' dist/activity/index.html 20
+
+          exit $fail
+
       - name: Set Cloudflare Pages production branch
         if: github.ref_name == 'master'
         env:


### PR DESCRIPTION
## 背景

既存の `Verify generated output` はファイルの存在（`test -f dist/index.html` など）しか見ていないため、**ビルドは成功するが中身が壊れている**という故障を検知できない。marked や独自のフロントマターパーサ／リンクカード生成が壊れても、431ページが「生成された」時点で緑になる。

#92 で minor/patch の自動マージを有効にしたので、この穴を塞いでおく価値が上がった。

## 変更

`Verify rendered content` ステップを追加し、各種コンテンツが実際に `dist/` に出力されていることを検証する。

| 対象 | しきい値 | 現状 |
|---|---|---|
| 総ページ数 | 400 | 430 |
| 記事 `<article class="post"` | 300 pages | 362 |
| 日記 `<article class="diary-entry"` | 40 pages | 60 |
| Amazonカード `krb-amzlt-box` | 120 pages | 166 |
| リンクカード `class="link-card"` | 3 pages | 6 |
| 温泉チェックイン | 40 (onsen/) | 61 |
| 山 | 30 (mountains/) | 47 |
| Stravaアクティビティ | 20 (activity/) | 31 |

しきい値は現状値の約7割に置いてあるので、通常の記事追加・削除では発動しない。エラーは最初の1件で打ち切らず全件出してから `exit $fail` する。

## 検証

実ビルドの `dist/` に対して確認済み：

- 正常な出力 → exit 0
- `krb-amzlt-box` を全削除 → `'krb-amzlt-box' on 0 page(s), expected at least 120` で落ちる
- 記事ディレクトリを300個削除 → ページ数・記事数・Amazonカードの3件を同時に報告して落ちる
- `activity/index.html` を空に → `appears 0 time(s) ... expected at least 20` で落ちる

新しいツールや依存は追加していない。既存の `test -f` の羅列と同じシェルスクリプトのまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmsBmpqyy5pn1nhtx9HXeN