### PR TITLE
Read hot spring composition sheets from check-in photos

### DIFF
--- a/.claude/commands/onsen-composition.md
+++ b/.claude/commands/onsen-composition.md
@@ -1,0 +1,108 @@
+---
+description: 温泉チェックイン写真から成分表を読み取り、astro/data/onsen_composition.json を更新する
+---
+
+温泉チェックイン写真に写っている温泉分析書・温泉成分等掲示表を読み取り、
+`astro/data/onsen_composition.json` を更新します。画像の判読はこの対話の中で行うので、
+API キーや外部サービスは不要です。
+
+以下の手順を順番に実行してください。
+
+## 1. 未解析の写真を集める
+
+```sh
+python3 scripts/prepare_onsen_composition.py
+```
+
+`astro/data/onsen_places.json` の写真を original 解像度で `.cache/onsen_photos/photos/` に落とし、
+選別用のコンタクトシート `.cache/onsen_photos/sheets/sheet-NN.jpg` と
+`.cache/onsen_photos/manifest.json` を作ります。すでに解析済みの写真（成分表だったもの・
+そうでなかったもの、どちらも）は自動でスキップされるので、通常は新しいチェックイン分だけが対象になります。
+
+「新しく解析する写真はありません。」と出たら、そこで終了して構いません。
+
+## 2. コンタクトシートで成分表を選別する
+
+`.cache/onsen_photos/sheets/` の各シートを Read で開き、**温泉分析書・温泉成分等掲示表・
+温泉分析書別表が写っているコマの番号**を書き出します。各コマの左下に `#12` のような番号が
+焼き込んであり、これが manifest の `index` に対応します。
+
+対象になるのは分析値や泉質が読み取れる掲示物だけです。施設の外観・料金表・のれん・
+食事・源泉名だけの看板などは対象外にします。
+
+## 3. 該当画像を精読する
+
+選んだ番号の画像を `.cache/onsen_photos/photos/` から Read で開き、記載内容を読み取ります。
+manifest の `file` にパスが入っています。小さくて読めない場合は Pillow でその部分を
+クロップ・拡大してから読み直してください。
+
+読み取る項目（掲示にあるものだけでよい）:
+
+- 源泉名、泉質、泉質の分類（低張性/等張性/高張性・酸性/中性/アルカリ性・冷鉱泉/温泉/高温泉）
+- 源泉温度、使用位置温度、湧出量、pH（湧出地・試験室の両方あれば両方）
+- 蒸発残留物、溶存物質、成分総計
+- 陽イオン・陰イオン・非解離成分・溶存ガス成分の各値と合計
+- 加水・加温・循環ろ過・消毒の有無とその理由
+- 泉質別適応症・泉質別禁忌症
+- 分析年月日（西暦に直す）、登録分析機関とその登録番号
+
+## 4. 書き起こしを JSON にする
+
+`.cache/onsen_photos/extracted.json` に次の形式で書きます。既存の同ファイルがあれば
+今回のぶんで置き換えて構いません（確定データは `astro/data/onsen_composition.json` 側にあります）。
+
+```json
+{
+  "places": [
+    {
+      "photo_indexes": [1],
+      "confidence": "high",
+      "spring_name": "…",
+      "spring_quality": "単純温泉",
+      "spring_quality_class": "低張性中性高温泉",
+      "source_temp_c": 47.0,
+      "ph": 7.1,
+      "total_ingredients_mg_kg": 713.4,
+      "cations": [{ "name": "ナトリウムイオン", "symbol": "Na+", "mg_kg": 146.5 }],
+      "cations_total_mg_kg": 174.0,
+      "treatment": { "kasui": { "applied": true, "reason": "…" } },
+      "indications": ["…"],
+      "analyzed_on": "2025-04-23",
+      "analyzer": "長野県薬剤師会"
+    }
+  ]
+}
+```
+
+守ること:
+
+- 数値の単位は **mg/kg に統一**する（分析書が g/kg なら 1000 倍する）。
+- 同じ施設の成分表が複数枚あるときは `photo_indexes` にまとめて並べる。
+- 施設名・住所・fsq_id は manifest から自動で埋まるので書かなくてよい。
+- 読み取りが怪しい値は**書かずに省く**。写真が不鮮明で全体的に自信がないときは
+  `"confidence": "low"`（多少怪しい程度なら `"medium"`）にして、`notes` に理由を書く。
+- 掲示が別表だけで成分値が無い場合も、泉質と適応症だけのエントリとして登録してよい。
+- **すでに登録済みの施設**を再訪して撮り直した場合は、変わった項目だけ書けばよい。
+  `astro/data/onsen_composition.json` の同じ `fsq_id` へ項目単位でマージされるので、
+  前回読み取った値は残り、今回書いた値だけが上書きされる。項目を消したいときだけ
+  `astro/data/onsen_composition.json` を直接編集する。
+
+## 5. データに反映する
+
+```sh
+python3 scripts/merge_onsen_composition.py
+```
+
+`extracted.json` に出てこなかった写真は「成分表ではなかった写真」として記録され、
+次回の `prepare_onsen_composition.py` の対象から外れます。
+
+## 6. 確認する
+
+```sh
+cd astro
+PATH=/home/peipeipe/.local/nodejs/current/bin:$PATH npm run build
+```
+
+`/onsen` ページ下部の「温泉成分表」セクションと、温泉一覧カードの泉質バッジに
+反映されていることを確認します。`.cache/` は gitignore 済みなので、コミット対象は
+`astro/data/onsen_composition.json` だけです。

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@ test.py
 .env.local
 .env.*.local
 
+# 温泉成分表の解析用に落とした写真キャッシュ
+.cache/
+
+# Claude Code のローカル設定（コマンド定義はコミットする）
+.claude/settings.local.json
+
 # Python仮想環境
 diary_bot_env/
 venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ python scripts/test_amazon_enhancement.py
 - Standalone URLs on their own line get turned into link cards (fetches OG/Twitter meta tags at build time, 2.5s timeout, cached in-memory) — except Amazon links in posts, which render a legacy "amazlet"-style affiliate card instead, and x.com/twitter.com links, which are left alone.
 - `layout` frontmatter fields on old Markdown are legacy Jekyll metadata and must not drive new rendering logic.
 
-Other structured data (`astro/data/*.json` — activities, mountains, onsen, places, books) is generated ahead of time by the Python scripts in `scripts/` and read at build time by the matching `astro/src/lib/*.ts` module (`activity.ts`, `mountains.ts`, `checkins.ts`, `books.ts`). These JSON files are checked in and refreshed by scheduled GitHub Actions workflows (`update-strava-activities.yml`, `update-onsen-checkins.yml`, `update-books-from-booklog.yml`), not regenerated on every build.
+Other structured data (`astro/data/*.json` — activities, mountains, onsen, places, books) is generated ahead of time by the Python scripts in `scripts/` and read at build time by the matching `astro/src/lib/*.ts` module (`activity.ts`, `mountains.ts`, `checkins.ts`, `books.ts`, `composition.ts`). These JSON files are checked in and refreshed by scheduled GitHub Actions workflows (`update-strava-activities.yml`, `update-onsen-checkins.yml`, `update-books-from-booklog.yml`), not regenerated on every build.
 
 Pages under `astro/src/pages/*-data.json.ts` expose some of this same data as JSON endpoints for client-side map/list rendering (used by `MapLayout.astro`).
 
@@ -50,6 +50,22 @@ python3 scripts/generate_visited_mountains.py   # if mountain data also needs up
 ```
 
 Never commit the export ZIP — it contains location data. If using the manual `Update Strava Activities From Export` workflow, only point `export_zip_url` at a short-lived URL.
+
+### Onsen composition data (manual, Claude-in-the-loop)
+
+`astro/data/onsen_composition.json` holds hot spring analysis sheets (温泉分析書 / 温泉成分等掲示表) transcribed from the Foursquare check-in photos in `astro/data/onsen_places.json`. There is no OCR service and no API key involved — the reading step happens inside a Claude Code session, driven by `.claude/commands/onsen-composition.md` (run `/onsen-composition`).
+
+```sh
+python3 scripts/prepare_onsen_composition.py   # 未解析写真を original 解像度で取得＋選別用シート生成
+# → Claude が .cache/onsen_photos/ の画像を読んで extracted.json を書く
+python3 scripts/merge_onsen_composition.py     # astro/data/onsen_composition.json に反映
+```
+
+Photo URLs are converted from Foursquare's `500x300` variant to `original` before download — the resized version is too small to read. Everything under `.cache/` is gitignored working data; only `astro/data/onsen_composition.json` gets committed. Photos that turn out not to be analysis sheets are recorded in `not_composition_photos` so the next run skips them, which is what makes the batch incremental. Re-visiting a venue and re-reading part of its posting is fine: `merge_onsen_composition.py` merges per field on `fsq_id`, so previously read values survive.
+
+Related: `fetch_foursquare_checkins.py` keeps **every** check-in photo per venue by default. Capping it via `FOURSQUARE_CHECKIN_PHOTOS_PER_PLACE` (1 or more; empty/0 means unlimited) makes newer check-ins push older photos out of `onsen_places.json`, which would silently drop analysis sheets that were never analyzed.
+
+The data renders inside `/onsen` (`onsen.astro`): a 泉質 badge on each check-in card plus a 温泉成分表 section below the map. `onsen-data.json.ts` also exposes a per-`fsq_id` summary so client-side re-rendering keeps the badges.
 
 ### Deploy
 

--- a/astro/data/onsen_composition.json
+++ b/astro/data/onsen_composition.json
@@ -1,0 +1,1744 @@
+{
+  "generated_on": "2026-07-26",
+  "stats": {
+    "places": 13,
+    "composition_photos": 14,
+    "not_composition_photos": 91
+  },
+  "places": [
+    {
+      "fsq_id": "4b6e35ddf964a520e5b12ce3",
+      "name": "ゆーぷる木崎湖",
+      "address": "平10639-1, 大町市, 長野県, 398-0001",
+      "checkin_date": "2026-07-25",
+      "confidence": "high",
+      "spring_name": "新第2源泉、平成の湯源泉、元湯一号、高瀬の湯との混合泉",
+      "spring_quality": "単純温泉",
+      "spring_quality_class": "低張性中性高温泉",
+      "source_temp_c": 47.0,
+      "use_temp_c": 42.0,
+      "ph": 7.1,
+      "ph_lab": 7.17,
+      "evaporation_residue_mg_kg": 583,
+      "dissolved_solids_mg_kg": 689.6,
+      "total_ingredients_mg_kg": 713.4,
+      "cations": [
+        {
+          "name": "リチウムイオン",
+          "symbol": "Li+",
+          "mg_kg": 0.8
+        },
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 146.5
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 8.9
+        },
+        {
+          "name": "マグネシウムイオン",
+          "symbol": "Mg2+",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 17.6
+        },
+        {
+          "name": "ストロンチウムイオン",
+          "symbol": "Sr2+",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "アルミニウムイオン",
+          "symbol": "Al3+",
+          "mg_kg": 0.02
+        },
+        {
+          "name": "マンガンイオン",
+          "symbol": "Mn2+",
+          "mg_kg": 0.03
+        }
+      ],
+      "cations_total_mg_kg": 174.0,
+      "anions": [
+        {
+          "name": "フッ化物イオン",
+          "symbol": "F-",
+          "mg_kg": 7.9
+        },
+        {
+          "name": "塩化物イオン",
+          "symbol": "Cl-",
+          "mg_kg": 164.7
+        },
+        {
+          "name": "臭化物イオン",
+          "symbol": "Br-",
+          "mg_kg": 0.3
+        },
+        {
+          "name": "硝酸イオン",
+          "symbol": "NO3-",
+          "mg_kg": 0.3
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 13.0
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 152.0
+        }
+      ],
+      "anions_total_mg_kg": 338.2,
+      "undissociated": [
+        {
+          "name": "メタケイ酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 174.0
+        },
+        {
+          "name": "メタホウ酸",
+          "symbol": "HBO2",
+          "mg_kg": 3.2
+        },
+        {
+          "name": "メタ亜ヒ酸",
+          "symbol": "HAsO2",
+          "mg_kg": 0.1
+        }
+      ],
+      "undissociated_total_mg_kg": 177.3,
+      "dissolved_gas": [
+        {
+          "name": "遊離二酸化炭素",
+          "symbol": "CO2",
+          "mg_kg": 23.8
+        }
+      ],
+      "dissolved_gas_total_mg_kg": 23.8,
+      "treatment": {
+        "kasui": {
+          "applied": true,
+          "reason": "源泉温度が高いので、加水しています。"
+        },
+        "kaon": {
+          "applied": true,
+          "reason": "入浴に適した温度に保つため、加温しています。"
+        },
+        "junkan": {
+          "applied": true,
+          "reason": "衛生管理のため、循環ろ過装置を使用しています。"
+        },
+        "shodoku": {
+          "applied": true,
+          "reason": "衛生管理のため、塩素系薬剤を使用しています。"
+        }
+      },
+      "indications": [
+        "自律神経不安定症",
+        "不眠症",
+        "うつ状態"
+      ],
+      "contraindications": [],
+      "analyzed_on": "2025-04-23",
+      "analyzer": "長野県薬剤師会",
+      "analyzer_registration": "長野県第2号",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_upbzMkXVV-LBv8AQmalIGM48quCGinxDpoHPbob5wCY.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4ee552f10e61681b9717a448",
+      "name": "ふるさとの湯",
+      "address": "豊郷8734, 野沢温泉村, 長野県, 389-2502",
+      "checkin_date": "2026-07-19",
+      "confidence": "medium",
+      "spring_name": "竹伸し、御嶽及び大欅の混合泉",
+      "spring_quality": "アルカリ性単純硫黄温泉",
+      "spring_quality_class": "低張性アルカリ性高温泉",
+      "source_temp_c": 69.7,
+      "use_temp_c": 40.0,
+      "ph": 8.5,
+      "ph_lab": 8.27,
+      "yield_l_min": 60.2,
+      "evaporation_residue_mg_kg": 861.8,
+      "dissolved_solids_mg_kg": 917,
+      "total_ingredients_mg_kg": 917,
+      "cations": [
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 179.2
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 5.4
+        },
+        {
+          "name": "アンモニウムイオン",
+          "symbol": "NH4+",
+          "mg_kg": 0.9
+        },
+        {
+          "name": "マグネシウムイオン",
+          "symbol": "Mg2+",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 66.7
+        },
+        {
+          "name": "ストロンチウムイオン",
+          "symbol": "Sr2+",
+          "mg_kg": 0.3
+        }
+      ],
+      "cations_total_mg_kg": 252.6,
+      "anions": [
+        {
+          "name": "フッ化物イオン",
+          "symbol": "F-",
+          "mg_kg": 1.1
+        },
+        {
+          "name": "塩化物イオン",
+          "symbol": "Cl-",
+          "mg_kg": 83.5
+        },
+        {
+          "name": "硫化水素イオン",
+          "symbol": "HS-",
+          "mg_kg": 18.0
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 389.0
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 26.2
+        },
+        {
+          "name": "炭酸イオン",
+          "symbol": "CO32-",
+          "mg_kg": 20.4
+        }
+      ],
+      "anions_total_mg_kg": 542.4,
+      "undissociated": [
+        {
+          "name": "メタケイ酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 115.2
+        },
+        {
+          "name": "メタホウ酸",
+          "symbol": "HBO2",
+          "mg_kg": 6.9
+        }
+      ],
+      "undissociated_total_mg_kg": 122.1,
+      "dissolved_gas": [
+        {
+          "name": "遊離硫化水素",
+          "symbol": "H2S",
+          "mg_kg": 0.6
+        }
+      ],
+      "dissolved_gas_total_mg_kg": 0.6,
+      "treatment": {
+        "kasui": {
+          "applied": true,
+          "reason": "適温にするため"
+        },
+        "kaon": {
+          "applied": false,
+          "reason": ""
+        },
+        "junkan": {
+          "applied": false,
+          "reason": ""
+        },
+        "shodoku": {
+          "applied": false,
+          "reason": ""
+        }
+      },
+      "indications": [
+        "自律神経不安定症",
+        "不眠症",
+        "うつ状態",
+        "アトピー性皮膚炎",
+        "尋常性乾癬",
+        "慢性湿疹",
+        "表皮化膿症"
+      ],
+      "contraindications": [
+        "皮膚又は粘膜の過敏な人",
+        "高齢者の皮膚乾燥症"
+      ],
+      "analyzed_on": "2018-10-13",
+      "analyzer": "環境未来株式会社",
+      "analyzer_registration": "長野県第6号",
+      "notes": "還元系温泉認定書も掲示（男湯湯口 ORP -146mV / pH 8.43 / 62.6℃）",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_Ct6QYpmg6HY9_4cny4Cm0hhoICQhsv69DCLKHpLohfc.jpg",
+        "https://fastly.4sqi.net/img/general/500x300/41463109_7cfoqnDhNkUlBmNGhdTwK8GgFvZ9SFINd2D3F7sIq1s.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4b67b25ff964a520295b2be3",
+      "name": "おぶせ温泉穴観音の湯",
+      "address": "雁田1194, 小布施町, 長野県, 381-0211",
+      "checkin_date": "2026-07-12",
+      "confidence": "high",
+      "spring_name": "おぶせ温泉",
+      "spring_quality": "含硫黄－カルシウム・ナトリウム－塩化物温泉",
+      "spring_quality_class": "低張性弱アルカリ性高温泉",
+      "source_temp_c": 44.1,
+      "use_temp_c": 44.1,
+      "ph": 8.37,
+      "evaporation_residue_mg_kg": 3144,
+      "dissolved_solids_mg_kg": 3471,
+      "total_ingredients_mg_kg": 3473,
+      "cations": [
+        {
+          "name": "リチウムイオン",
+          "symbol": "Li+",
+          "mg_kg": 0.2
+        },
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 386.3
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 11.6
+        },
+        {
+          "name": "アンモニウムイオン",
+          "symbol": "NH4+",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "マグネシウムイオン",
+          "symbol": "Mg2+",
+          "mg_kg": 0.6
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 799.5
+        },
+        {
+          "name": "ストロンチウムイオン",
+          "symbol": "Sr2+",
+          "mg_kg": 2.6
+        }
+      ],
+      "cations_total_mg_kg": 1201.0,
+      "anions": [
+        {
+          "name": "フッ化物イオン",
+          "symbol": "F-",
+          "mg_kg": 0.7
+        },
+        {
+          "name": "塩化物イオン",
+          "symbol": "Cl-",
+          "mg_kg": 1773.0
+        },
+        {
+          "name": "臭化物イオン",
+          "symbol": "Br-",
+          "mg_kg": 5.5
+        },
+        {
+          "name": "ヨウ化物イオン",
+          "symbol": "I-",
+          "mg_kg": 1.7
+        },
+        {
+          "name": "硫化水素イオン",
+          "symbol": "HS-",
+          "mg_kg": 38.7
+        },
+        {
+          "name": "チオ硫酸イオン",
+          "symbol": "S2O32-",
+          "mg_kg": 3.7
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 321.0
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 70.2
+        },
+        {
+          "name": "炭酸イオン",
+          "symbol": "CO32-",
+          "mg_kg": 1.9
+        }
+      ],
+      "anions_total_mg_kg": 2216.0,
+      "undissociated": [
+        {
+          "name": "メタケイ酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 39.0
+        },
+        {
+          "name": "メタホウ酸",
+          "symbol": "HBO2",
+          "mg_kg": 15.0
+        }
+      ],
+      "undissociated_total_mg_kg": 54.0,
+      "dissolved_gas": [
+        {
+          "name": "遊離硫化水素",
+          "symbol": "H2S",
+          "mg_kg": 1.7
+        }
+      ],
+      "dissolved_gas_total_mg_kg": 1.7,
+      "indications": [],
+      "contraindications": [],
+      "analyzed_on": "2024-06-21",
+      "analyzer": "長野市薬剤師会",
+      "analyzer_registration": "長野県第8号",
+      "notes": "総ヒ素 0.038 mg/kg。掲示上の泉質表記は「硫黄泉」",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_WRGd8l8iFaaIDcyF-sqDcpHnXwQyW-crqJ1DJ9rdV3c.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4c9582340341370492cd7cef",
+      "name": "天狗温泉浅間山荘",
+      "address": "甲又4766-2, 小諸市, 長野県, 384-0801",
+      "checkin_date": "2026-07-11",
+      "confidence": "high",
+      "spring_name": "天狗温泉",
+      "spring_quality": "単純鉄(II)冷鉱泉［炭酸水素塩型］",
+      "spring_quality_class": "低張性弱酸性冷鉱泉",
+      "source_temp_c": 8.4,
+      "ph": 5.9,
+      "ph_lab": 5.77,
+      "yield_l_min": 47.6,
+      "evaporation_residue_mg_kg": 322,
+      "dissolved_solids_mg_kg": 515.7,
+      "total_ingredients_mg_kg": 1260,
+      "cations": [
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 8.4
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 2.2
+        },
+        {
+          "name": "マグネシウムイオン",
+          "symbol": "Mg2+",
+          "mg_kg": 9.6
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 40.1
+        },
+        {
+          "name": "ストロンチウムイオン",
+          "symbol": "Sr2+",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "マンガンイオン",
+          "symbol": "Mn2+",
+          "mg_kg": 0.8
+        },
+        {
+          "name": "鉄(II)イオン",
+          "symbol": "Fe2+",
+          "mg_kg": 48.0
+        }
+      ],
+      "cations_total_mg_kg": 109.2,
+      "anions": [
+        {
+          "name": "フッ化物イオン",
+          "symbol": "F-",
+          "mg_kg": 0.07
+        },
+        {
+          "name": "塩化物イオン",
+          "symbol": "Cl-",
+          "mg_kg": 1.4
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 0.3
+        },
+        {
+          "name": "リン酸二水素イオン",
+          "symbol": "H2PO4-",
+          "mg_kg": 0.3
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 298.4
+        }
+      ],
+      "anions_total_mg_kg": 300.5,
+      "undissociated": [
+        {
+          "name": "メタケイ酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 106.0
+        },
+        {
+          "name": "メタホウ酸",
+          "symbol": "HBO2",
+          "mg_kg": 0.03
+        }
+      ],
+      "undissociated_total_mg_kg": 106.0,
+      "dissolved_gas": [
+        {
+          "name": "遊離二酸化炭素",
+          "symbol": "CO2",
+          "mg_kg": 743.6
+        },
+        {
+          "name": "遊離硫化水素",
+          "symbol": "H2S",
+          "mg_kg": 0.2
+        }
+      ],
+      "dissolved_gas_total_mg_kg": 743.8,
+      "indications": [],
+      "contraindications": [],
+      "analyzed_on": "2017-11-10",
+      "analyzer": "上田薬剤師会 検査センター",
+      "notes": "自然湧出。知覚的試験は「ほとんど無色澄明、強鉄味、炭酸味、微硫化水素臭」、翌日には黄濁",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_ZhXHv12MhH3qIy6WjkGuNfu55q523XZcdOk4MALbdMw.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4c76043ac219224b1a47a428",
+      "name": "つつじの湯",
+      "address": "田代930, 嬬恋村, 群馬県, 377-1614",
+      "checkin_date": "2026-07-05",
+      "confidence": "high",
+      "spring_name": "嬬恋高原温泉 つつじの湯",
+      "spring_quality": "ナトリウム・カルシウム－炭酸水素塩・塩化物温泉",
+      "spring_quality_class": "中性低張性温泉",
+      "source_temp_c": 38.5,
+      "use_temp_c": 41.0,
+      "ph": 7.36,
+      "yield_l_min": 210,
+      "evaporation_residue_mg_kg": 1450,
+      "total_ingredients_mg_kg": 1940,
+      "cations": [
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 350
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 39.6
+        },
+        {
+          "name": "マグネシウムイオン",
+          "symbol": "Mg2+",
+          "mg_kg": 49.5
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 110
+        },
+        {
+          "name": "鉄(II)イオン",
+          "symbol": "Fe2+",
+          "mg_kg": 1.76
+        },
+        {
+          "name": "マンガンイオン",
+          "symbol": "Mn2+",
+          "mg_kg": 1.01
+        },
+        {
+          "name": "アルミニウムイオン",
+          "symbol": "Al3+",
+          "mg_kg": 0.11
+        },
+        {
+          "name": "ストロンチウムイオン",
+          "symbol": "Sr2+",
+          "mg_kg": 0.69
+        }
+      ],
+      "cations_total_mg_kg": 553,
+      "anions": [
+        {
+          "name": "フッ素イオン",
+          "symbol": "F-",
+          "mg_kg": 0.3
+        },
+        {
+          "name": "塩素イオン",
+          "symbol": "Cl-",
+          "mg_kg": 447
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 1.6
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 783
+        },
+        {
+          "name": "炭酸イオン",
+          "symbol": "CO32-",
+          "mg_kg": 0.5
+        },
+        {
+          "name": "臭素イオン",
+          "symbol": "Br-",
+          "mg_kg": 1.7
+        }
+      ],
+      "anions_total_mg_kg": 1235,
+      "undissociated": [
+        {
+          "name": "メタけい酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 113
+        },
+        {
+          "name": "メタほう酸",
+          "symbol": "HBO2",
+          "mg_kg": 0.7
+        }
+      ],
+      "undissociated_total_mg_kg": 114,
+      "dissolved_gas": [
+        {
+          "name": "遊離二酸化炭素",
+          "symbol": "CO2",
+          "mg_kg": 42.7
+        },
+        {
+          "name": "遊離硫化水素",
+          "symbol": "H2S",
+          "mg_kg": 0.0
+        }
+      ],
+      "dissolved_gas_total_mg_kg": 42.7,
+      "treatment": {
+        "kasui": {
+          "applied": false,
+          "reason": "加水していません。"
+        },
+        "kaon": {
+          "applied": true,
+          "reason": "入浴に適した温度に保つために加温しています。"
+        },
+        "junkan": {
+          "applied": true,
+          "reason": "浴槽の入れ替え時に昇温のため、循環をしております。"
+        },
+        "shodoku": {
+          "applied": true,
+          "reason": "群馬県公衆浴場条例の基準を満たすため塩素系薬剤による消毒を行っております。"
+        }
+      },
+      "indications": [
+        "神経痛",
+        "筋肉痛",
+        "関節痛",
+        "五十肩",
+        "痔疾",
+        "運動麻痺",
+        "関節のこわばり",
+        "うちみ",
+        "くじき",
+        "慢性消化器病",
+        "冷え性",
+        "病後回復期",
+        "疲労回復",
+        "健康増進",
+        "切り傷",
+        "やけど",
+        "慢性皮膚病",
+        "虚弱児童",
+        "慢性婦人病"
+      ],
+      "contraindications": [],
+      "analyzed_on": "2006-08-07",
+      "analyzer": "群馬県薬剤師会",
+      "analyzer_registration": "群馬県第2号",
+      "notes": "掲示表の泉質説明では「炭酸水素塩泉＝美肌の湯」「塩化物泉＝保湿効果が高くよく温まる」と紹介。スケール付着防止剤（ポリアクリル酸ナトリウム）を使用",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_wV7rgObv08GHHc1fQKI-SHerl6VVM_RjHmZPyjZgtR4.jpg"
+      ]
+    },
+    {
+      "fsq_id": "6a1075c6f4446c63a65bf819",
+      "name": "黄金の湯松代荘",
+      "address": "松代町東条3541, 長野市, 長野県",
+      "checkin_date": "2026-06-29",
+      "confidence": "high",
+      "spring_name": "新3号泉",
+      "spring_quality": "ナトリウム・カルシウム－塩化物温泉",
+      "spring_quality_class": "高張性中性高温泉",
+      "source_temp_c": 43.8,
+      "ph": 6.7,
+      "ph_lab": 6.61,
+      "evaporation_residue_mg_kg": 15500,
+      "dissolved_solids_mg_kg": 16130,
+      "total_ingredients_mg_kg": 16850,
+      "cations": [
+        {
+          "name": "リチウムイオン",
+          "symbol": "Li+",
+          "mg_kg": 6.0
+        },
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 3546
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 451.5
+        },
+        {
+          "name": "アンモニウムイオン",
+          "symbol": "NH4+",
+          "mg_kg": 0.6
+        },
+        {
+          "name": "マグネシウムイオン",
+          "symbol": "Mg2+",
+          "mg_kg": 287.1
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 1140
+        },
+        {
+          "name": "ストロンチウムイオン",
+          "symbol": "Sr2+",
+          "mg_kg": 14.7
+        },
+        {
+          "name": "バリウムイオン",
+          "symbol": "Ba2+",
+          "mg_kg": 0.3
+        },
+        {
+          "name": "アルミニウムイオン",
+          "symbol": "Al3+",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "マンガンイオン",
+          "symbol": "Mn2+",
+          "mg_kg": 2.0
+        },
+        {
+          "name": "鉄(II)イオン",
+          "symbol": "Fe2+",
+          "mg_kg": 19.5
+        },
+        {
+          "name": "銅イオン",
+          "symbol": "Cu2+",
+          "mg_kg": 0.3
+        }
+      ],
+      "cations_total_mg_kg": 5468,
+      "anions": [
+        {
+          "name": "フッ化物イオン",
+          "symbol": "F-",
+          "mg_kg": 0.6
+        },
+        {
+          "name": "塩化物イオン",
+          "symbol": "Cl-",
+          "mg_kg": 7002
+        },
+        {
+          "name": "臭化物イオン",
+          "symbol": "Br-",
+          "mg_kg": 14.9
+        },
+        {
+          "name": "ヨウ化物イオン",
+          "symbol": "I-",
+          "mg_kg": 7.5
+        },
+        {
+          "name": "亜硝酸イオン",
+          "symbol": "NO2-",
+          "mg_kg": 0.04
+        },
+        {
+          "name": "硫化水素イオン",
+          "symbol": "HS-",
+          "mg_kg": 0.02
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 307.3
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 2150
+        }
+      ],
+      "anions_total_mg_kg": 9482,
+      "undissociated": [
+        {
+          "name": "メタケイ酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 179.1
+        },
+        {
+          "name": "メタホウ酸",
+          "symbol": "HBO2",
+          "mg_kg": 1000
+        },
+        {
+          "name": "メタ亜ヒ酸",
+          "symbol": "HAsO2",
+          "mg_kg": 0.5
+        }
+      ],
+      "undissociated_total_mg_kg": 1180,
+      "dissolved_gas": [
+        {
+          "name": "遊離二酸化炭素",
+          "symbol": "CO2",
+          "mg_kg": 716.5
+        },
+        {
+          "name": "遊離硫化水素",
+          "symbol": "H2S",
+          "mg_kg": 0.05
+        }
+      ],
+      "dissolved_gas_total_mg_kg": 716.6,
+      "indications": [
+        "きりきず",
+        "うつ状態",
+        "末梢循環障害",
+        "冷え症",
+        "皮膚乾燥症"
+      ],
+      "contraindications": [],
+      "analyzed_on": "2019-04-19",
+      "analyzer": "長野県薬剤師会",
+      "analyzer_registration": "長野県第2号",
+      "notes": "採水地は松代荘露天風呂湯口。知覚的試験は「ほとんど無色澄明、鹹味・鉄味・炭酸味、二酸化炭素の噴出を認める」",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_KrVoGW9vbowUnnN-ZF0iLCxrXYJr0OovsUnXgCkTeDM.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4bdd2df8b0f5c92842ee4be3",
+      "name": "ホットプラザ浅間",
+      "address": "浅間温泉3-16-3, 松本市, 長野県, 390-0303",
+      "checkin_date": "2026-06-28",
+      "confidence": "high",
+      "spring_name": "第2,4号源泉、山田源泉、大下源泉、東北源泉の混合泉",
+      "spring_quality": "アルカリ性単純温泉",
+      "spring_quality_class": "低張性アルカリ性高温泉",
+      "indications": [
+        "自律神経不安定症",
+        "うつ状態",
+        "不眠症"
+      ],
+      "contraindications": [],
+      "analyzed_on": "2016-05-27",
+      "analyzer": "長野県薬剤師会",
+      "analyzer_registration": "長野県第2号",
+      "notes": "掲示は温泉分析書別表（浴用）のみで、成分値の記載なし。採水地は松本市浅間温泉3丁目670-3（温泉中央分湯場分湯槽）",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_xPFm_erCuuUfXAtV5eZsRiy8uMA2vSotS28Hl5meTEc.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4b679f6ef964a52045582be3",
+      "name": "万葉超音波温泉",
+      "address": "磯部1125, 千曲市, 長野県, 389-0806",
+      "checkin_date": "2026-06-25",
+      "confidence": "high",
+      "spring_name": "翠明荘3号泉",
+      "spring_quality": "アルカリ性単純硫黄温泉",
+      "spring_quality_class": "低張性アルカリ性高温泉",
+      "source_temp_c": 46.2,
+      "ph": 8.8,
+      "ph_lab": 8.39,
+      "evaporation_residue_mg_kg": 440,
+      "dissolved_solids_mg_kg": 466.6,
+      "total_ingredients_mg_kg": 466.8,
+      "cations": [
+        {
+          "name": "リチウムイオン",
+          "symbol": "Li+",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 126.5
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 2.4
+        },
+        {
+          "name": "マグネシウムイオン",
+          "symbol": "Mg2+",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 15.5
+        },
+        {
+          "name": "ストロンチウムイオン",
+          "symbol": "Sr2+",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "マンガンイオン",
+          "symbol": "Mn2+",
+          "mg_kg": 0.02
+        }
+      ],
+      "cations_total_mg_kg": 144.7,
+      "anions": [
+        {
+          "name": "フッ化物イオン",
+          "symbol": "F-",
+          "mg_kg": 1.0
+        },
+        {
+          "name": "塩化物イオン",
+          "symbol": "Cl-",
+          "mg_kg": 128.6
+        },
+        {
+          "name": "臭化物イオン",
+          "symbol": "Br-",
+          "mg_kg": 0.4
+        },
+        {
+          "name": "硫化水素イオン",
+          "symbol": "HS-",
+          "mg_kg": 8.4
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 62.7
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 49.3
+        },
+        {
+          "name": "炭酸イオン",
+          "symbol": "CO32-",
+          "mg_kg": 8.4
+        }
+      ],
+      "anions_total_mg_kg": 258.9,
+      "undissociated": [
+        {
+          "name": "メタけい酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 58.3
+        },
+        {
+          "name": "メタほう酸",
+          "symbol": "HBO2",
+          "mg_kg": 4.7
+        }
+      ],
+      "undissociated_total_mg_kg": 63.0,
+      "dissolved_gas": [
+        {
+          "name": "遊離硫化水素",
+          "symbol": "H2S",
+          "mg_kg": 0.2
+        }
+      ],
+      "dissolved_gas_total_mg_kg": 0.2,
+      "indications": [],
+      "contraindications": [],
+      "analyzed_on": "2021-07-02",
+      "analyzer": "上田薬剤師会 検査センター",
+      "analyzer_registration": "長野県第7号",
+      "notes": "掘削動力揚湯（ボアホールポンプ）。知覚的試験は「ほとんど無色澄明、強硫黄味・硫化水素臭」",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_ppqd7Rk5sq5LLZr9l4Qyqx7bZvYoBjLNcA3gjzylhEc.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4b7786f5f964a520ef9f2ee3",
+      "name": "湯楽里館",
+      "address": "和3875, 東御市, 長野県, 389-0505",
+      "checkin_date": "2026-06-14",
+      "confidence": "high",
+      "spring_name": "みづほ温泉",
+      "spring_quality": "ナトリウム－塩化物・炭酸水素塩泉",
+      "spring_quality_class": "弱アルカリ性低張性高温泉",
+      "source_temp_c": 53.9,
+      "use_temp_c": 31.9,
+      "ph": 8.31,
+      "ph_lab": 8.38,
+      "yield_l_min": 50.4,
+      "evaporation_residue_mg_kg": 886,
+      "dissolved_solids_mg_kg": 976,
+      "total_ingredients_mg_kg": 997,
+      "cations": [
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 242.5
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 5.6
+        },
+        {
+          "name": "アンモニウムイオン",
+          "symbol": "NH4+",
+          "mg_kg": 1.0
+        },
+        {
+          "name": "マグネシウムイオン",
+          "symbol": "Mg2+",
+          "mg_kg": 0.6
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 7.4
+        },
+        {
+          "name": "バリウムイオン",
+          "symbol": "Ba2+",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "鉄(II)イオン",
+          "symbol": "Fe2+",
+          "mg_kg": 0.1
+        }
+      ],
+      "cations_total_mg_kg": 257.3,
+      "anions": [
+        {
+          "name": "ふっ素イオン",
+          "symbol": "F-",
+          "mg_kg": 0.4
+        },
+        {
+          "name": "塩素イオン",
+          "symbol": "Cl-",
+          "mg_kg": 282.2
+        },
+        {
+          "name": "臭素イオン",
+          "symbol": "Br-",
+          "mg_kg": 0.8
+        },
+        {
+          "name": "よう素イオン",
+          "symbol": "I-",
+          "mg_kg": 0.6
+        },
+        {
+          "name": "硝酸イオン",
+          "symbol": "NO3-",
+          "mg_kg": 0.9
+        },
+        {
+          "name": "硫化水素イオン",
+          "symbol": "HS-",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 1.2
+        },
+        {
+          "name": "りん酸水素イオン",
+          "symbol": "H2PO4-",
+          "mg_kg": 0.2
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 335.6
+        },
+        {
+          "name": "炭酸イオン",
+          "symbol": "CO32-",
+          "mg_kg": 21.0
+        }
+      ],
+      "anions_total_mg_kg": 643.0,
+      "undissociated": [
+        {
+          "name": "メタけい酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 50.5
+        },
+        {
+          "name": "メタほう酸",
+          "symbol": "HBO2",
+          "mg_kg": 25.6
+        }
+      ],
+      "undissociated_total_mg_kg": 76.1,
+      "dissolved_gas": [
+        {
+          "name": "遊離二酸化炭素",
+          "symbol": "CO2",
+          "mg_kg": 21.0
+        }
+      ],
+      "dissolved_gas_total_mg_kg": 21.0,
+      "indications": [
+        "きりきず",
+        "末梢循環障害",
+        "冷え性",
+        "うつ状態",
+        "皮膚乾燥症"
+      ],
+      "contraindications": [],
+      "analyzed_on": "2024-04-10",
+      "analyzer": "株式会社科学技術開発センター",
+      "analyzer_registration": "長野県第3号",
+      "notes": "動力揚湯。電気伝導率 0.130 S/m。施設取入口では pH 8.22 / 31.9℃",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109__7fZeQ5AxG93l0ZdcbpNIPHjUtja6246iJXN9qXTowM.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4cf3806e88de3704e63d7f2b",
+      "name": "白糸の湯",
+      "address": "里山辺85-1, 松本市, 長野県, 390-0221",
+      "checkin_date": "2026-05-30",
+      "confidence": "high",
+      "spring_name": "第2、第3、第4、第5源泉の混合泉",
+      "spring_quality": "アルカリ性単純温泉",
+      "spring_quality_class": "低張性アルカリ性高温泉",
+      "source_temp_c": 42.4,
+      "ph": 8.7,
+      "ph_lab": 8.82,
+      "evaporation_residue_mg_kg": 418,
+      "dissolved_solids_mg_kg": 439.8,
+      "total_ingredients_mg_kg": 439.8,
+      "cations": [
+        {
+          "name": "リチウムイオン",
+          "symbol": "Li+",
+          "mg_kg": 0.04
+        },
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 89.7
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 1.1
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 32.3
+        },
+        {
+          "name": "ストロンチウムイオン",
+          "symbol": "Sr2+",
+          "mg_kg": 0.2
+        },
+        {
+          "name": "アルミニウムイオン",
+          "symbol": "Al3+",
+          "mg_kg": 0.01
+        }
+      ],
+      "cations_total_mg_kg": 123.4,
+      "anions": [
+        {
+          "name": "フッ化物イオン",
+          "symbol": "F-",
+          "mg_kg": 1.3
+        },
+        {
+          "name": "塩化物イオン",
+          "symbol": "Cl-",
+          "mg_kg": 28.5
+        },
+        {
+          "name": "臭化物イオン",
+          "symbol": "Br-",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "チオ硫酸イオン",
+          "symbol": "S2O32-",
+          "mg_kg": 0.3
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 210.3
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 30.2
+        },
+        {
+          "name": "炭酸イオン",
+          "symbol": "CO32-",
+          "mg_kg": 2.4
+        }
+      ],
+      "anions_total_mg_kg": 273.1,
+      "undissociated": [
+        {
+          "name": "メタケイ酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 42.5
+        },
+        {
+          "name": "メタホウ酸",
+          "symbol": "HBO2",
+          "mg_kg": 0.8
+        }
+      ],
+      "undissociated_total_mg_kg": 43.3,
+      "dissolved_gas": [],
+      "dissolved_gas_total_mg_kg": 0,
+      "indications": [],
+      "contraindications": [],
+      "analyzed_on": "2023-04-27",
+      "analyzer": "長野県薬剤師会",
+      "analyzer_registration": "長野県第2号",
+      "notes": "採水地は松本市大字里山辺129番地（配湯所内混合泉採取口）。総ヒ素 0.004 mg/kg",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_SlS0-vIUbrWCl5IrHel1KbaY20USuTdWcq9M6zd5VIQ.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4d954d3e577cba7a3afb7779",
+      "name": "扉温泉 桧の湯",
+      "address": "入山辺8967-4-28 (山辺地区農業生活改善センター), 松本市, 長野県, 390-0222",
+      "checkin_date": "2026-05-04",
+      "confidence": "high",
+      "spring_name": "扉温泉 桧の湯",
+      "spring_quality": "アルカリ性単純温泉",
+      "spring_quality_class": "低張性アルカリ性温泉",
+      "source_temp_c": 41.5,
+      "ph": 9.2,
+      "ph_lab": 9.18,
+      "yield_l_min": 312,
+      "evaporation_residue_mg_kg": 656,
+      "dissolved_solids_mg_kg": 670.7,
+      "total_ingredients_mg_kg": 670.7,
+      "cations": [
+        {
+          "name": "リチウムイオン",
+          "symbol": "Li+",
+          "mg_kg": 0.03
+        },
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 103.5
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 1.8
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 90.9
+        },
+        {
+          "name": "ストロンチウムイオン",
+          "symbol": "Sr2+",
+          "mg_kg": 0.5
+        }
+      ],
+      "cations_total_mg_kg": 196.7,
+      "anions": [
+        {
+          "name": "フッ化物イオン",
+          "symbol": "F-",
+          "mg_kg": 0.7
+        },
+        {
+          "name": "塩化物イオン",
+          "symbol": "Cl-",
+          "mg_kg": 8.1
+        },
+        {
+          "name": "臭化物イオン",
+          "symbol": "Br-",
+          "mg_kg": 0.05
+        },
+        {
+          "name": "水酸化物イオン",
+          "symbol": "OH-",
+          "mg_kg": 0.3
+        },
+        {
+          "name": "硫化水素イオン",
+          "symbol": "HS-",
+          "mg_kg": 0.3
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 403.1
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 4.9
+        },
+        {
+          "name": "炭酸イオン",
+          "symbol": "CO32-",
+          "mg_kg": 7.8
+        },
+        {
+          "name": "メタホウ酸イオン",
+          "symbol": "BO2-",
+          "mg_kg": 0.4
+        }
+      ],
+      "anions_total_mg_kg": 425.6,
+      "undissociated": [
+        {
+          "name": "メタケイ酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 48.3
+        }
+      ],
+      "undissociated_total_mg_kg": 48.3,
+      "dissolved_gas": [],
+      "dissolved_gas_total_mg_kg": 0,
+      "indications": [],
+      "contraindications": [],
+      "analyzed_on": "2022-01-19",
+      "analyzer": "長野県薬剤師会",
+      "analyzer_registration": "長野県第2号",
+      "notes": "掘削による自噴。現場フロート形面積流量計の読みは312L/分。総ヒ素 0.005 mg/kg",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_4kozC08uLgOjQwRypGeNWEBlJBI1eDj26-eZsgUw_uY.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4d0dab7d873e6a313a335bd6",
+      "name": "六番湯 目洗の湯",
+      "address": "平穏, 山ノ内町, 長野県, 381-0401",
+      "checkin_date": "2026-04-26",
+      "confidence": "high",
+      "spring_name": "目洗いの湯、ガニ沢の湯の混合泉",
+      "spring_quality": "ナトリウム・カルシウム－硫酸塩・塩化物温泉",
+      "spring_quality_class": "低張性中性高温泉",
+      "source_temp_c": 50.6,
+      "ph": 7.4,
+      "ph_lab": 7.51,
+      "evaporation_residue_mg_kg": 1072,
+      "dissolved_solids_mg_kg": 1090,
+      "total_ingredients_mg_kg": 1097,
+      "cations": [
+        {
+          "name": "リチウムイオン",
+          "symbol": "Li+",
+          "mg_kg": 0.5
+        },
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 183.2
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 15.7
+        },
+        {
+          "name": "マグネシウムイオン",
+          "symbol": "Mg2+",
+          "mg_kg": 4.1
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 110.1
+        },
+        {
+          "name": "ストロンチウムイオン",
+          "symbol": "Sr2+",
+          "mg_kg": 0.5
+        },
+        {
+          "name": "アルミニウムイオン",
+          "symbol": "Al3+",
+          "mg_kg": 0.03
+        },
+        {
+          "name": "マンガンイオン",
+          "symbol": "Mn2+",
+          "mg_kg": 0.07
+        }
+      ],
+      "cations_total_mg_kg": 314.2,
+      "anions": [
+        {
+          "name": "ふっ化物イオン",
+          "symbol": "F-",
+          "mg_kg": 1.0
+        },
+        {
+          "name": "塩化物イオン",
+          "symbol": "Cl-",
+          "mg_kg": 222.0
+        },
+        {
+          "name": "臭化物イオン",
+          "symbol": "Br-",
+          "mg_kg": 1.3
+        },
+        {
+          "name": "硝酸イオン",
+          "symbol": "NO3-",
+          "mg_kg": 0.1
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 350.0
+        },
+        {
+          "name": "りん酸一水素イオン",
+          "symbol": "HPO42-",
+          "mg_kg": 0.6
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 37.3
+        }
+      ],
+      "anions_total_mg_kg": 612.3,
+      "undissociated": [
+        {
+          "name": "メタけい酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 129.3
+        },
+        {
+          "name": "メタほう酸",
+          "symbol": "HBO2",
+          "mg_kg": 33.6
+        },
+        {
+          "name": "メタ亜ひ酸",
+          "symbol": "HAsO2",
+          "mg_kg": 0.7
+        }
+      ],
+      "undissociated_total_mg_kg": 163.6,
+      "dissolved_gas": [
+        {
+          "name": "遊離二酸化炭素",
+          "symbol": "CO2",
+          "mg_kg": 6.4
+        }
+      ],
+      "dissolved_gas_total_mg_kg": 6.4,
+      "indications": [],
+      "contraindications": [],
+      "analyzed_on": "2016-06-10",
+      "analyzer": "上田薬剤師会 検査センター",
+      "analyzer_registration": "長野県第7号",
+      "notes": "自然湧出。採水地は渋温泉 六番湯 目洗いの湯の浴槽湯口",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_PafyUbdHmpbjOgRl-KPpvLiqMkzionJS4FM8AUqDMYg.jpg"
+      ]
+    },
+    {
+      "fsq_id": "4c133fb77f7f2d7f7cd4de68",
+      "name": "コタン温泉 (コタン温泉 露天風呂)",
+      "address": "屈斜路古丹, 弟子屈町, 北海道, 088-3341",
+      "checkin_date": "2024-07-02",
+      "confidence": "low",
+      "spring_quality": "ナトリウム－炭酸水素塩泉",
+      "spring_quality_class": "中性低張性高温泉",
+      "source_temp_c": 59.6,
+      "ph": 6.8,
+      "ph_lab": 6.65,
+      "evaporation_residue_mg_kg": 782,
+      "dissolved_solids_mg_kg": 1046,
+      "total_ingredients_mg_kg": 1280,
+      "cations": [
+        {
+          "name": "ナトリウムイオン",
+          "symbol": "Na+",
+          "mg_kg": 151.4
+        },
+        {
+          "name": "カリウムイオン",
+          "symbol": "K+",
+          "mg_kg": 7.1
+        },
+        {
+          "name": "マグネシウムイオン",
+          "symbol": "Mg2+",
+          "mg_kg": 8.9
+        },
+        {
+          "name": "カルシウムイオン",
+          "symbol": "Ca2+",
+          "mg_kg": 31.1
+        },
+        {
+          "name": "鉄(II)イオン",
+          "symbol": "Fe2+",
+          "mg_kg": 1.6
+        },
+        {
+          "name": "アンモニウムイオン",
+          "symbol": "NH4+",
+          "mg_kg": 0.3
+        }
+      ],
+      "cations_total_mg_kg": 199.8,
+      "anions": [
+        {
+          "name": "ふっ化物イオン",
+          "symbol": "F-",
+          "mg_kg": 0.9
+        },
+        {
+          "name": "塩化物イオン",
+          "symbol": "Cl-",
+          "mg_kg": 46.0
+        },
+        {
+          "name": "硫化水素イオン",
+          "symbol": "HS-",
+          "mg_kg": 0.2
+        },
+        {
+          "name": "硫酸イオン",
+          "symbol": "SO42-",
+          "mg_kg": 1.2
+        },
+        {
+          "name": "炭酸水素イオン",
+          "symbol": "HCO3-",
+          "mg_kg": 488.6
+        },
+        {
+          "name": "炭酸イオン",
+          "symbol": "CO32-",
+          "mg_kg": 0.2
+        },
+        {
+          "name": "りん酸イオン",
+          "symbol": "HPO42-",
+          "mg_kg": 0.4
+        }
+      ],
+      "anions_total_mg_kg": 537.5,
+      "undissociated": [
+        {
+          "name": "メタけい酸",
+          "symbol": "H2SiO3",
+          "mg_kg": 286.9
+        },
+        {
+          "name": "メタほう酸",
+          "symbol": "HBO2",
+          "mg_kg": 21.9
+        }
+      ],
+      "undissociated_total_mg_kg": 308.8,
+      "dissolved_gas": [
+        {
+          "name": "遊離二酸化炭素",
+          "symbol": "CO2",
+          "mg_kg": 234.0
+        },
+        {
+          "name": "遊離硫化水素",
+          "symbol": "H2S",
+          "mg_kg": 0.2
+        }
+      ],
+      "dissolved_gas_total_mg_kg": 234.3,
+      "indications": [],
+      "contraindications": [],
+      "analyzed_on": "2016-07-21",
+      "analyzer": "株式会社第一岸本鉱泉検査センター",
+      "analyzer_registration": "北海道第12号",
+      "notes": "写真の解像度が低く、数値の読み取り精度は低め。マンガンイオンは判読できず除外。動力揚湯、電気伝導率 0.69 S/m",
+      "source_photos": [
+        "https://fastly.4sqi.net/img/general/500x300/41463109_UR3zveXZgXC4R8Ml7ByO1637jdUKAMCXb7sqg7hEFBE.jpg"
+      ]
+    }
+  ],
+  "not_composition_photos": [
+    "https://fastly.4sqi.net/img/general/500x300/41463109_NMrF4NUx2x7-ukCkTbo_09RrEtBbImQ4feU17mYLOOc.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_Z_egmbl1hPG44ftsMjMS2cOPzYzzUZ0QFAzpdbJD_iY.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_Khhc5zf5ur_PvVT6lIHf2SmLjXU1l2nif0TgtxA8MsI.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_Zh6j_ue_RvdPODqvdrvSK4j5Bb_RSGVc2YH8OaVJDro.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_Mj8_oDLFLZasC7hGfNoaVotCNff887UAWN2P71DgF5M.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_Jec4fju9elLBuafJTo9vO01fVpAKsY65XtnA0hVtNbw.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_TKRzl85N0PukYEanaK6qANpipDxGVBkBkJ9g6Fi3f7g.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_AZeQRzq-KOk14oRWsPjpYiD514HZVRnfgjym_TKIfJI.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_tAcHxqryU5DBosBGxns7VG1A2MJSBmeCY0PYYKWXdlo.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_uUONscfATyY5iEClsW0Vi8vY_wmqXCB_iwjZI914njo.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_LhgRG6qk5LUijfJbejOmPv9uh5kbcw7i5nszJmwQots.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_R1AxOOVqfOdD4JSYDjpeYDRLdBcBwSZ9YZ5GZmgFqks.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_mc4pqveJa7iDe7-MELyxqz67X3zE67HPUAFkY3bW4FU.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_iQOQ6vVLZKbIVdP07ALAjPUxWGEKvOB73SZlV4t2Jn8.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_YQEcYYVIpy5Qao4U5Wbxvad60pjRJtorzhh1S3TbioM.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_a1vDkCfgiTai7sV6xHDTFyLLBYKbLHFgWRbLVkjTruo.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_6AICLRUKZxk8kSQzRe7gP5SundN-i-K5n8lfltYIRSM.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_-q_AOYdHuSArP_d-V-2p3uJr5fKVpbKT2ZVWus0_dQ4.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_HgnOzYUf_PrQnQcfofh_t2U_l4_HRp0Lkkmh95ITeWk.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_VWczFtKQ37dfaQRmlCkE813fGWeHGX-b5em1N-XktCE.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_N1_cgkhejji0zKNFukihGANkEnhx3l4rFvtt8oCKR8I.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_GqQ3BTz40vYEK_4T1d48fWg5PR-EiLeaIHCxSkruCMA.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_n7QwLjTUeqgaK6DJnyXE2xuZI_Bpcl2R4Jj2q7l3sV0.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_VaFQFzItIsB6XUg-sTmwC8sUtDcvJcZEJq3mgFWgBf8.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109__OSfCiR0OmAVs738j7YGk5K049eSrgP3a-ySU8bB_OU.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_nBG-RlfAoknCphLg1w9SqE07bPNMpvEiimJLZhHlmBU.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_JHMWbQ21aKLLDq9uRSbKc87QzaTyqsaUnY54w4XxD_A.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_-DxTDRXMwmbbHDhI8pG0tgS8jKnQhFx7wjNSNwIeEt4.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_CQ9Bn6H67f1QO33gtyvFeSrQMJh4b9pwzp2gS5f0H3I.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_2Sy0RSu5J-QWKROjV-js_R_a0mXJM46VDSrrE1XwQWc.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_AwyLMUO0XvHD0juIcp6oAAUF0e4fZIY9LaasAQqypjU.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_9xntp0VfM6c4v_Pu5wWxS7M8TFQUOI0AiVdUge2Vv5U.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_rcpetPMmMXlqa6B1Nd5XEpglyR7jyLq7X8UdtiahHtU.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_rynjBRpP38PaTWmjbqhb0pAHsG6DyPdUeSOd04CHSwE.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_gj3gcwONQa_XJ-ZlzAzuU1Atmok1OdEdmeVWoaSZpn0.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_MNcXgEiDygDXpMKcfXK4hPmQzsaKI7hmQa64547XflE.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_yzXwaLB198vTmdJBwkiqcY6MIr6JLC__ISBoj-jxMC0.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_oDPcXqCoF7eiRUOcZzSNjvb-ZCAcuDnU1nC7xAgSMLI.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_lFGBtFGk0_V3g75yV5tKZM28EFM4ghe93L9En1mynmg.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_OCWww4E_362lQTZAf0PKxi4epA_BB33VQOexD6x4RIc.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_wg6sNMfrtxQhTTQlFo2sh2Hmjv1A7cd4gOF-ZRivV_E.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_6c1Gw-USWizTqekYF75GKL6l_kk2zolQoqxnPAaoP4A.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_mogbhIqHEmKY9euwlO79Faf3zaKTMlJPjsZJq7qy2Os.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_2rBrbijt8aTkVcOKNqxNLhIBPufiMEfyPTz46ZUDNBE.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_Bp3rutIVEMF9u5GHaKRZza5q0lYJMQRncSLkyM7noXw.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_8io_i2oTaY-Jl-z_f6qMFHnkhnDAb4c61j_308-0oyA.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_5pXbgwUC6Vz9doKCawbUgRUYOZFZmydvmO8e_1w9eAY.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_hNP4K1Yap__FZTlSA7U_px7fc7CqPnV2qIA5ZsHNTlg.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_cwjqlIGG_r057jn53Uw0HWM33HKuxIv4XrA-1foc56c.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_1n52IdN-jIQXQaEHnf6Ra2kd0nhHbf-8U500zAnhulw.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_d_zTsW7IAqE69E0qo3dVoD6BIekSUMmqfG2k-x80tVI.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_a_xR3WFEz-xwtyZiZZu8i7tMXmC_5OqLk-uEeJ5ozDg.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_9o-p5A8wYC_ZtN8Nq9Y3vzvjklVSYp6Kn6XuoYV1zH0.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_gZ-_D3II4LOp4DdHzlqX5lpbjTzvHV4_slofCBIHj7s.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_dgwo1Q95J51sxAZQBA4rmHpdPo17-KwSBjEuAx0Lqog.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_dDRieM4LKH9fnz4RNFlYf6MNDj51htZILRt90khphPU.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_UiSw53tr9iwM-TE4U2R1QZeIEuhdGxBuBJStikiY5jk.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_I6Eflb9c8I--lB_j0NmYAqvjUAjcLatW-dY3j0QxElY.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_EseAs8sFCKykP-os3fH-bHLmnQZq5mHC5s_U5L2m3fQ.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_48hQd0viKBXo1c8lwjWfiCsDXM7mzpIaH92IHvP0D6k.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_vNKpqO4MzsuwkzYrDbi6eTWOLB8tx3oj59Acp3oNsm8.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_Iz8kMAm_VnKLTMN6h2qfN3ddjzgaaD3Cfnxj4bKbsao.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_kVSELBaymVBqyIJOTC8pjkM15h2Ti94OTBb2sx3HkdI.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_BcTGrrBG6vfRo8BCxT0qmvnFzQLJRfSweARMVc3_l-U.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_mIPekhDIsQX0Maf4PLmGt0XkvQ9JuHfiCXeRXHlO6FE.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_r4gT86BS-m4OU47GN0nDjJkdxiZ8R8uWHq5fX4vYso4.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_d-WvZOqAboUt8xcqEM9v1zcVVWQ04XOpy9Cm7Rja3Ok.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_D2TwNIg5Fk-1g792qIPGTShW4IayYLjHTZbj-mFHc7M.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_kSCe120ZAuDZnR5lwm-Y_dHshyTHJXuBe2XQTKwiak0.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_OL5Lal97BZ6e8YdfJk3RKZGUZe0Vfz27nIDgKa1D3q0.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_jNycFj38XUfjwtqIokJM2_O3QiEorM4nmN5xC8Xlc8Y.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_M2i1Psfj_Ld8x4RJalkGXGuA5wT-W_hQlhVyC6X1gUA.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_qYsI9fCmmYi5wYrGu4UUYXm1PiiH9Jh_352Ih1fOeFg.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_VwU21_da_rUgpa0DOVurePLDREG88TsDlgDcvn4UPtM.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_Uly0GEPpzsEIeU--E2TqbhqoQZHdInuchkro5ZRphHI.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_grFfmG0NnpgB6SNhJJK7TW5LduNUvfXLSA2vy4WWcSI.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_AQbVgaZdFudishS4rgRO8c8UmAxX1vs9TINh-csmbnk.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_6tm8qDsY14V2psTShqMNJ-g4eLP0VHgackQun34F2fs.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_yyQ_Otn4go8usc298tP_UaSD-YxFi92wLIMz8I4xckM.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_uE1eNTnHBHoqZEsWU3FcUr5JIDyGpR1Ftm1_4dbk22o.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_KtThY0NtlblDoOjmSTm27aS5SErtQfxJEOMDnAqOpX4.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_ERvc40Dra5YgUaFUBu8mYT6n6XpA0g9uoKDcMo8yzuo.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_WhPbnhHtj8QV3uyaV32P9QPP-bGTzxeS3dXNw6UVQA8.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_-zBkQAJ-SWR4tJRuzw2qRqxtLmTIxa02AtqUCcKXfCs.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_mcVm_NfgcOzSISyTMKltnNK1CFnx73cyz2-iavrRjz4.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_aEqkpG_NSwD1frYjiJj1HRMb05Th7m4Az6Znoddh0_M.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_mlBdGxwnUW5UhPrHJ0bQDBBIyCYi7CemKyYovqVa09Q.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_9g2G53BurMlQ8526WFMrhrH6xdJvfAT0evIJq2ARyho.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_iYoJrZrWfpYjWZAJY1P4O8fmfurJ_uftvbeUdV2w7ec.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_eohT7Ou0X36l7MiLwC7P_DWzAFY-90HsF_rvhRPcZZY.jpg",
+    "https://fastly.4sqi.net/img/general/500x300/41463109_cEEz6oJSCGrWEhxYnvuqaq17W9wvcW7m_F4p-OsExho.jpg"
+  ]
+}

--- a/astro/src/lib/composition.ts
+++ b/astro/src/lib/composition.ts
@@ -1,0 +1,199 @@
+import compositionData from "../../data/onsen_composition.json";
+
+export type CompositionIngredient = {
+  name: string;
+  symbol?: string;
+  mg_kg?: number | null;
+};
+
+export type CompositionTreatment = {
+  applied?: boolean;
+  reason?: string;
+};
+
+export type OnsenComposition = {
+  fsq_id: string;
+  name: string;
+  address?: string;
+  checkin_date?: string;
+  confidence?: "high" | "medium" | "low";
+  spring_name?: string;
+  spring_quality?: string;
+  spring_quality_class?: string;
+  source_temp_c?: number | null;
+  use_temp_c?: number | null;
+  ph?: number | null;
+  ph_lab?: number | null;
+  yield_l_min?: number | null;
+  evaporation_residue_mg_kg?: number | null;
+  dissolved_solids_mg_kg?: number | null;
+  total_ingredients_mg_kg?: number | null;
+  cations?: CompositionIngredient[];
+  cations_total_mg_kg?: number | null;
+  anions?: CompositionIngredient[];
+  anions_total_mg_kg?: number | null;
+  undissociated?: CompositionIngredient[];
+  undissociated_total_mg_kg?: number | null;
+  dissolved_gas?: CompositionIngredient[];
+  dissolved_gas_total_mg_kg?: number | null;
+  treatment?: Record<string, CompositionTreatment>;
+  indications?: string[];
+  contraindications?: string[];
+  analyzed_on?: string;
+  analyzer?: string;
+  analyzer_registration?: string;
+  notes?: string;
+  source_photos?: string[];
+};
+
+type CompositionData = {
+  generated_on?: string;
+  stats?: {
+    places?: number;
+    composition_photos?: number;
+    not_composition_photos?: number;
+  };
+  places?: OnsenComposition[];
+  not_composition_photos?: string[];
+};
+
+// 掲示の「加水・加温・循環・消毒」を表示順に固定する
+export const TREATMENT_LABELS: { key: string; label: string }[] = [
+  { key: "kasui", label: "加水" },
+  { key: "kaon", label: "加温" },
+  { key: "junkan", label: "循環ろ過" },
+  { key: "shodoku", label: "消毒" },
+];
+
+const data = compositionData as CompositionData;
+
+export function getOnsenCompositions(): OnsenComposition[] {
+  return data.places || [];
+}
+
+export function getCompositionMap(): Map<string, OnsenComposition> {
+  return new Map(
+    getOnsenCompositions()
+      .filter((entry) => entry.fsq_id)
+      .map((entry) => [entry.fsq_id, entry]),
+  );
+}
+
+/** 一覧のバッジや検索インデックス向けに、施設ごとの要約だけを返す */
+export function compositionSummaryByFsqId() {
+  const summary: Record<
+    string,
+    { quality?: string; qualityClass?: string; ph?: number | null; sourceTemp?: number | null; total?: number | null }
+  > = {};
+
+  getOnsenCompositions().forEach((entry) => {
+    if (!entry.fsq_id) return;
+    summary[entry.fsq_id] = {
+      quality: entry.spring_quality,
+      qualityClass: entry.spring_quality_class,
+      ph: entry.ph ?? null,
+      sourceTemp: entry.source_temp_c ?? null,
+      total: entry.total_ingredients_mg_kg ?? null,
+    };
+  });
+
+  return summary;
+}
+
+export function summarizeCompositions(entries: OnsenComposition[] = getOnsenCompositions()) {
+  const withPh = entries.filter((entry) => typeof entry.ph === "number");
+  const withTotal = entries.filter((entry) => typeof entry.total_ingredients_mg_kg === "number");
+
+  const mostAlkaline = withPh.reduce<OnsenComposition | null>(
+    (current, entry) => (!current || (entry.ph as number) > (current.ph as number) ? entry : current),
+    null,
+  );
+  const richest = withTotal.reduce<OnsenComposition | null>(
+    (current, entry) =>
+      !current || (entry.total_ingredients_mg_kg as number) > (current.total_ingredients_mg_kg as number)
+        ? entry
+        : current,
+    null,
+  );
+  const hottest = entries.reduce<OnsenComposition | null>(
+    (current, entry) =>
+      typeof entry.source_temp_c === "number" &&
+      (!current || entry.source_temp_c > (current.source_temp_c as number))
+        ? entry
+        : current,
+    null,
+  );
+
+  return {
+    count: entries.length,
+    photos: entries.reduce((sum, entry) => sum + (entry.source_photos?.length || 0), 0),
+    mostAlkaline,
+    richest,
+    hottest,
+    generatedOn: data.generated_on || "",
+  };
+}
+
+/** 「単純温泉」「ナトリウム－塩化物温泉」など、泉質名でまとめたカウント */
+export function qualityBreakdown(entries: OnsenComposition[] = getOnsenCompositions()) {
+  const counts = new Map<string, number>();
+  entries.forEach((entry) => {
+    const quality = entry.spring_quality;
+    if (!quality) return;
+    counts.set(quality, (counts.get(quality) || 0) + 1);
+  });
+
+  return [...counts.entries()]
+    .map(([quality, count]) => ({ quality, count }))
+    .sort((a, b) => b.count - a.count || a.quality.localeCompare(b.quality, "ja"));
+}
+
+export type QualityGroup = {
+  key: string;
+  label: string;
+};
+
+/** 散布図の色分け用に、泉質名をおおまかな系統へ寄せる */
+export function qualityGroup(entry: OnsenComposition): QualityGroup {
+  const quality = entry.spring_quality || "";
+
+  if (quality.includes("硫黄")) return { key: "sulfur", label: "硫黄泉" };
+  if (quality.includes("鉄")) return { key: "iron", label: "鉄泉" };
+  if (quality.includes("単純温泉")) return { key: "simple", label: "単純温泉" };
+  if (quality.includes("塩化物")) return { key: "chloride", label: "塩化物泉" };
+  if (quality.includes("炭酸水素塩")) return { key: "bicarbonate", label: "炭酸水素塩泉" };
+  if (quality.includes("硫酸塩")) return { key: "sulfate", label: "硫酸塩泉" };
+  return { key: "other", label: "その他" };
+}
+
+export type ScatterPoint = {
+  fsqId: string;
+  name: string;
+  ph: number;
+  total: number;
+  group: QualityGroup;
+};
+
+export function scatterPoints(entries: OnsenComposition[] = getOnsenCompositions()): ScatterPoint[] {
+  return entries
+    .filter(
+      (entry) => typeof entry.ph === "number" && typeof entry.total_ingredients_mg_kg === "number",
+    )
+    .map((entry) => ({
+      fsqId: entry.fsq_id,
+      name: entry.name,
+      ph: entry.ph as number,
+      total: entry.total_ingredients_mg_kg as number,
+      group: qualityGroup(entry),
+    }));
+}
+
+export function formatMgKg(value?: number | null) {
+  if (typeof value !== "number") return "";
+  if (value >= 1000) return `${value.toLocaleString("ja-JP")} mg/kg`;
+  return `${value} mg/kg`;
+}
+
+export function formatTemp(value?: number | null) {
+  return typeof value === "number" ? `${value}℃` : "";
+}

--- a/astro/src/pages/onsen-data.json.ts
+++ b/astro/src/pages/onsen-data.json.ts
@@ -1,8 +1,10 @@
 import { getOnsenPlaces, summarizePlaces } from "@/lib/checkins";
+import { compositionSummaryByFsqId } from "@/lib/composition";
 
 export async function GET() {
   const places = getOnsenPlaces();
   const stats = summarizePlaces(places);
+  const composition = compositionSummaryByFsqId();
 
   return new Response(
     JSON.stringify(
@@ -19,6 +21,7 @@ export async function GET() {
               }
             : null,
         },
+        composition,
         places,
       },
       null,

--- a/astro/src/pages/onsen.astro
+++ b/astro/src/pages/onsen.astro
@@ -1,10 +1,27 @@
 ---
 import MapLayout from "@/layouts/MapLayout.astro";
 import { getOnsenPlaces, summarizePlaces, type CheckinPlace } from "@/lib/checkins";
+import {
+  formatMgKg,
+  formatTemp,
+  getCompositionMap,
+  getOnsenCompositions,
+  qualityBreakdown,
+  scatterPoints,
+  summarizeCompositions,
+  TREATMENT_LABELS,
+  type CompositionIngredient,
+  type OnsenComposition,
+} from "@/lib/composition";
 
 const places = getOnsenPlaces();
 const stats = summarizePlaces(places);
 const recentPlaces = places.slice(0, 60);
+
+const compositions = getOnsenCompositions();
+const compositionMap = getCompositionMap();
+const compositionStats = summarizeCompositions(compositions);
+const qualities = qualityBreakdown(compositions);
 
 const googleMapsUrl = (place: CheckinPlace) => {
   const lat = Number(place.lat);
@@ -13,6 +30,80 @@ const googleMapsUrl = (place: CheckinPlace) => {
   const query = [place.name, coordinates].filter(Boolean).join(" ");
   return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
 };
+
+// 掲示から拾えた指標だけをバッジにする
+const compositionBadges = (entry: OnsenComposition) =>
+  [
+    typeof entry.source_temp_c === "number" ? `源泉 ${formatTemp(entry.source_temp_c)}` : "",
+    typeof entry.ph === "number" ? `pH ${entry.ph}` : "",
+    typeof entry.total_ingredients_mg_kg === "number" ? `成分総計 ${formatMgKg(entry.total_ingredients_mg_kg)}` : "",
+  ].filter(Boolean);
+
+const ingredientGroups = (entry: OnsenComposition) =>
+  [
+    { label: "陽イオン", items: entry.cations, total: entry.cations_total_mg_kg },
+    { label: "陰イオン", items: entry.anions, total: entry.anions_total_mg_kg },
+    { label: "非解離成分", items: entry.undissociated, total: entry.undissociated_total_mg_kg },
+    { label: "溶存ガス", items: entry.dissolved_gas, total: entry.dissolved_gas_total_mg_kg },
+  ].filter((group) => (group.items?.length || 0) > 0) as {
+    label: string;
+    items: CompositionIngredient[];
+    total?: number | null;
+  }[];
+
+const treatmentEntries = (entry: OnsenComposition) =>
+  TREATMENT_LABELS.map(({ key, label }) => ({ label, value: entry.treatment?.[key] })).filter(
+    (item) => item.value && typeof item.value.applied === "boolean",
+  );
+
+const confidenceLabel: Record<string, string> = {
+  high: "",
+  medium: "読み取り精度: 中",
+  low: "読み取り精度: 低",
+};
+
+// --- pH × 成分総計の散布図 ---
+const CHART = { width: 720, height: 400, left: 58, right: 18, top: 18, bottom: 46 };
+const PH_DOMAIN = [5.5, 9.5];
+const TOTAL_DOMAIN = [300, 20000];
+const plotWidth = CHART.width - CHART.left - CHART.right;
+const plotHeight = CHART.height - CHART.top - CHART.bottom;
+
+const phToX = (ph: number) =>
+  CHART.left + ((ph - PH_DOMAIN[0]) / (PH_DOMAIN[1] - PH_DOMAIN[0])) * plotWidth;
+const totalToY = (total: number) => {
+  const ratio =
+    (Math.log10(total) - Math.log10(TOTAL_DOMAIN[0])) /
+    (Math.log10(TOTAL_DOMAIN[1]) - Math.log10(TOTAL_DOMAIN[0]));
+  return CHART.top + plotHeight - ratio * plotHeight;
+};
+
+const phTicks = [6, 7, 8, 9];
+const totalTicks = [300, 1000, 3000, 10000];
+
+// ラベルが重ならないよう、点ごとに空いているオフセットを順に試す
+const labelOffsets = [-11, 15, -23, 27, -35];
+const placedLabels: { x: number; y: number }[] = [];
+const plotted = scatterPoints(compositions)
+  .slice()
+  .sort((a, b) => b.total - a.total)
+  .map((point) => {
+    const x = phToX(point.ph);
+    const y = totalToY(point.total);
+    const dy =
+      labelOffsets.find(
+        (offset) =>
+          !placedLabels.some(
+            (placed) => Math.abs(placed.x - x) < 78 && Math.abs(placed.y - (y + offset)) < 12,
+          ),
+      ) ?? labelOffsets[0];
+    placedLabels.push({ x, y: y + dy });
+
+    const anchor = x > CHART.left + plotWidth - 70 ? "end" : x < CHART.left + 70 ? "start" : "middle";
+    return { ...point, x, y, dy, anchor };
+  });
+
+const scatterGroups = [...new Map(plotted.map((point) => [point.group.key, point.group])).values()];
 ---
 
 <MapLayout
@@ -38,6 +129,10 @@ const googleMapsUrl = (place: CheckinPlace) => {
         <div>
           <strong>{stats.withPhotos.toLocaleString()}</strong>
           <span>Photos</span>
+        </div>
+        <div>
+          <strong>{compositionStats.count.toLocaleString()}</strong>
+          <span>成分表</span>
         </div>
         <div>
           <strong>{stats.latest?.date || ""}</strong>
@@ -90,6 +185,12 @@ const googleMapsUrl = (place: CheckinPlace) => {
                       <span>{place.date}</span>
                     </div>
                     <h3>{place.name}</h3>
+                    {place.fsq_id && compositionMap.has(place.fsq_id) && (
+                      <p class="checkin-item-quality">
+                        <span class="quality-mark">分析書</span>
+                        <span class="quality-text">{compositionMap.get(place.fsq_id)!.spring_quality}</span>
+                      </p>
+                    )}
                     <p class="checkin-item-address">{place.address}</p>
                     {place.user_comment && <p class="checkin-item-comment">{place.user_comment}</p>}
                   </div>
@@ -113,6 +214,251 @@ const googleMapsUrl = (place: CheckinPlace) => {
         <div class="checkin-empty" id="onsen-empty" hidden>表示できる温泉がありません。</div>
       </aside>
     </div>
+
+    <section class="composition-section" id="composition" aria-label="温泉成分表">
+      <header class="composition-header">
+        <div>
+          <h2>温泉成分表</h2>
+          <p>
+            チェックイン写真に写っていた温泉分析書・成分掲示表を読み取ってまとめたものです。数値は掲示の記載そのままで、
+            単位は mg/kg に揃えています。
+          </p>
+        </div>
+        <dl class="composition-stats" aria-label="成分表の統計">
+          <div>
+            <dt>施設</dt>
+            <dd>{compositionStats.count}</dd>
+          </div>
+          {compositionStats.hottest && (
+            <div>
+              <dt>最高源泉温度</dt>
+              <dd>{formatTemp(compositionStats.hottest.source_temp_c)}</dd>
+            </div>
+          )}
+          {compositionStats.mostAlkaline && (
+            <div>
+              <dt>最高pH</dt>
+              <dd>{compositionStats.mostAlkaline.ph}</dd>
+            </div>
+          )}
+          {compositionStats.richest && (
+            <div>
+              <dt>最高成分総計</dt>
+              <dd>{formatMgKg(compositionStats.richest.total_ingredients_mg_kg)}</dd>
+            </div>
+          )}
+        </dl>
+      </header>
+
+      {qualities.length > 0 && (
+        <ul class="composition-qualities" aria-label="泉質の内訳">
+          {qualities.map((item) => (
+            <li>
+              <span>{item.quality}</span>
+              <strong>{item.count}</strong>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div class="composition-charts">
+        <figure class="composition-chart">
+          <figcaption>
+            <strong>pH と成分総計</strong>
+            <span>右へ行くほどアルカリ性、上へ行くほど濃い温泉です（縦軸は対数）。</span>
+          </figcaption>
+
+          <ul class="scatter-legend">
+            {scatterGroups.map((group) => (
+              <li>
+                <span class={`scatter-swatch quality-${group.key}`} aria-hidden="true"></span>
+                {group.label}
+              </li>
+            ))}
+          </ul>
+
+          <div class="scatter-wrap">
+            <svg
+              class="scatter-chart"
+              viewBox={`0 0 ${CHART.width} ${CHART.height}`}
+              role="img"
+              aria-label={`pHと成分総計の散布図。${plotted.length}施設をプロットしています。`}
+            >
+              {totalTicks.map((tick) => (
+                <>
+                  <line
+                    class="scatter-grid"
+                    x1={CHART.left}
+                    x2={CHART.width - CHART.right}
+                    y1={totalToY(tick)}
+                    y2={totalToY(tick)}
+                  />
+                  <text class="scatter-tick" x={CHART.left - 9} y={totalToY(tick) + 4} text-anchor="end">
+                    {tick.toLocaleString("ja-JP")}
+                  </text>
+                </>
+              ))}
+
+              {phTicks.map((tick) => (
+                <>
+                  <line
+                    class="scatter-grid"
+                    x1={phToX(tick)}
+                    x2={phToX(tick)}
+                    y1={CHART.top}
+                    y2={CHART.top + plotHeight}
+                  />
+                  <text
+                    class="scatter-tick"
+                    x={phToX(tick)}
+                    y={CHART.top + plotHeight + 20}
+                    text-anchor="middle"
+                  >
+                    pH {tick}
+                  </text>
+                </>
+              ))}
+
+              <text class="scatter-axis" x={CHART.left - 9} y={CHART.top - 4} text-anchor="end">
+                mg/kg
+              </text>
+
+              {plotted.map((point) => (
+                <>
+                  <circle class={`scatter-dot quality-${point.group.key}`} cx={point.x} cy={point.y} r="6" />
+                  <text
+                    class="scatter-label"
+                    x={point.x}
+                    y={point.y + point.dy}
+                    text-anchor={point.anchor}
+                  >
+                    {point.name}
+                  </text>
+                </>
+              ))}
+            </svg>
+          </div>
+        </figure>
+      </div>
+
+      <div class="composition-items">
+        {compositions.map((entry) => (
+          <details class="composition-item">
+            <summary>
+              <div class="composition-item-head">
+                <h3>{entry.name}</h3>
+                <p class="composition-quality">{entry.spring_quality}</p>
+                {entry.spring_quality_class && <p class="composition-quality-class">{entry.spring_quality_class}</p>}
+              </div>
+              <ul class="composition-badges">
+                {compositionBadges(entry).map((badge) => (
+                  <li>{badge}</li>
+                ))}
+              </ul>
+            </summary>
+
+            <div class="composition-body">
+              <dl class="composition-meta">
+                {entry.spring_name && (
+                  <div>
+                    <dt>源泉名</dt>
+                    <dd>{entry.spring_name}</dd>
+                  </div>
+                )}
+                {typeof entry.use_temp_c === "number" && (
+                  <div>
+                    <dt>使用位置温度</dt>
+                    <dd>{formatTemp(entry.use_temp_c)}</dd>
+                  </div>
+                )}
+                {typeof entry.yield_l_min === "number" && (
+                  <div>
+                    <dt>湧出量</dt>
+                    <dd>{entry.yield_l_min} L/分</dd>
+                  </div>
+                )}
+                {typeof entry.dissolved_solids_mg_kg === "number" && (
+                  <div>
+                    <dt>溶存物質</dt>
+                    <dd>{formatMgKg(entry.dissolved_solids_mg_kg)}</dd>
+                  </div>
+                )}
+                {typeof entry.evaporation_residue_mg_kg === "number" && (
+                  <div>
+                    <dt>蒸発残留物</dt>
+                    <dd>{formatMgKg(entry.evaporation_residue_mg_kg)}</dd>
+                  </div>
+                )}
+              </dl>
+
+              {treatmentEntries(entry).length > 0 && (
+                <ul class="composition-treatment" aria-label="加水・加温・循環・消毒">
+                  {treatmentEntries(entry).map((item) => (
+                    <li class={item.value!.applied ? "is-applied" : "is-none"}>
+                      <span>{item.label}</span>
+                      <strong>{item.value!.applied ? "あり" : "なし"}</strong>
+                      {item.value!.reason && <em>{item.value!.reason}</em>}
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {ingredientGroups(entry).length > 0 && (
+                <div class="composition-tables">
+                  {ingredientGroups(entry).map((group) => (
+                    <table class="composition-table">
+                      <caption>
+                        {group.label}
+                        {typeof group.total === "number" && <span>計 {formatMgKg(group.total)}</span>}
+                      </caption>
+                      <tbody>
+                        {group.items.map((item) => (
+                          <tr>
+                            <th scope="row">
+                              {item.name}
+                              {item.symbol && <span class="composition-symbol">{item.symbol}</span>}
+                            </th>
+                            <td>{typeof item.mg_kg === "number" ? item.mg_kg.toLocaleString("ja-JP") : "—"}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  ))}
+                </div>
+              )}
+
+              {(entry.indications?.length || entry.contraindications?.length) && (
+                <div class="composition-symptoms">
+                  {entry.indications?.length ? (
+                    <p>
+                      <span class="composition-symptom-label">泉質別適応症</span>
+                      {entry.indications.join("、")}
+                    </p>
+                  ) : null}
+                  {entry.contraindications?.length ? (
+                    <p>
+                      <span class="composition-symptom-label is-warn">泉質別禁忌症</span>
+                      {entry.contraindications.join("、")}
+                    </p>
+                  ) : null}
+                </div>
+              )}
+
+              {entry.notes && <p class="composition-notes">{entry.notes}</p>}
+
+              <p class="composition-source">
+                {entry.analyzed_on && <span>分析 {entry.analyzed_on}</span>}
+                {entry.analyzer && <span>{entry.analyzer}</span>}
+                {entry.analyzer_registration && <span>{entry.analyzer_registration}</span>}
+                {entry.confidence && confidenceLabel[entry.confidence] && (
+                  <span class="composition-confidence">{confidenceLabel[entry.confidence]}</span>
+                )}
+              </p>
+            </div>
+          </details>
+        ))}
+      </div>
+    </section>
   </section>
 
   <div class="photo-lightbox" id="onsen-lightbox" role="dialog" aria-modal="true" aria-hidden="true">
@@ -129,6 +475,7 @@ const googleMapsUrl = (place: CheckinPlace) => {
     const DATA_URL = "/onsen-data.json";
     const LIST_LIMIT = 80;
     let placesData = [];
+    let compositionByFsqId = {};
     let map;
     let markerLayer;
     let canvasRenderer;
@@ -137,7 +484,15 @@ const googleMapsUrl = (place: CheckinPlace) => {
     let searchTimer = null;
 
     function searchableText(place) {
-      return [place.name, place.address, place.user_comment, (place.categories || []).join(" ")]
+      const composition = compositionByFsqId[place.fsq_id];
+      return [
+        place.name,
+        place.address,
+        place.user_comment,
+        (place.categories || []).join(" "),
+        composition ? composition.quality : "",
+        composition ? composition.qualityClass : "",
+      ]
         .join(" ")
         .toLowerCase();
     }
@@ -215,6 +570,10 @@ const googleMapsUrl = (place: CheckinPlace) => {
             ? `<button class="checkin-item-photo checkin-item-photo-btn" type="button" data-lightbox-index="${place._index}" aria-label="${escapeHtml(place.name || "")}の写真を拡大 (${photoCount}枚)"><img src="${escapeHtml(place.photos[0])}" alt="${escapeHtml(place.name || "")}の写真" loading="lazy">${photoCount > 1 ? `<span class="checkin-item-photo-count">📷 ${photoCount}</span>` : ""}</button>`
             : '<div class="checkin-item-photo checkin-item-photo--empty"><div class="checkin-item-placeholder">♨️</div></div>';
           const comment = place.user_comment ? `<p class="checkin-item-comment">${escapeHtml(place.user_comment)}</p>` : "";
+          const quality = compositionByFsqId[place.fsq_id];
+          const qualityBlock = quality && quality.quality
+            ? `<p class="checkin-item-quality"><span class="quality-mark">分析書</span><span class="quality-text">${escapeHtml(quality.quality)}</span></p>`
+            : "";
           const mapsUrl = googleMapsUrl(place);
           return `
             <article class="checkin-item" id="onsen-item-${place._index}">
@@ -226,6 +585,7 @@ const googleMapsUrl = (place: CheckinPlace) => {
                     <span>${escapeHtml(place.date || "")}</span>
                   </div>
                   <h3>${escapeHtml(place.name || "")}</h3>
+                  ${qualityBlock}
                   <p class="checkin-item-address">${escapeHtml(place.address || "")}</p>
                   ${comment}
                 </div>
@@ -373,6 +733,7 @@ const googleMapsUrl = (place: CheckinPlace) => {
       const response = await fetch(DATA_URL);
       if (!response.ok) throw new Error("onsen-data.json load failed");
       const payload = await response.json();
+      compositionByFsqId = payload.composition || {};
       placesData = Array.isArray(payload.places) ? payload.places : [];
       placesData.forEach((place, index) => {
         place._index = index;

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -1149,6 +1149,14 @@ body.photo-lightbox-open {
   font-size: 12px;
 }
 
+/* Let the ellipsis/line-clamp inside side-panel cards win over long titles
+   instead of the card widening and forcing a horizontal scroll. */
+.activity-item-body,
+.mountain-item-body,
+.checkin-item-body {
+  min-width: 0;
+}
+
 .activity-list {
   display: grid;
   gap: 10px;

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -1472,6 +1472,36 @@ body.photo-lightbox-open {
   text-align: center;
 }
 
+.checkin-item-quality {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  margin: 5px 0 0;
+  overflow: hidden;
+  color: var(--color-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.checkin-item-quality .quality-mark {
+  flex: 0 0 auto;
+  border: 1px solid var(--map-accent);
+  border-radius: 4px;
+  color: var(--map-accent);
+  padding: 0 4px;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+/* 長い泉質名でカードが広がらないよう、住所・コメントと同じ2行クランプに揃える */
+.checkin-item-quality .quality-text {
+  display: -webkit-box;
+  min-width: 0;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
 .popup-image {
   position: relative;
   display: block;
@@ -1514,6 +1544,461 @@ body.photo-lightbox-open {
 
 .popup-map-link {
   margin-top: 8px;
+}
+
+/* 温泉成分表（/onsen ページ下部） */
+.composition-section {
+  margin-top: 28px;
+  border-top: 1px solid var(--color-border-soft);
+  padding-top: 22px;
+}
+
+.composition-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: end;
+}
+
+.composition-header h2 {
+  margin: 0;
+  color: var(--color-heading);
+  font-size: 21px;
+}
+
+.composition-header p {
+  margin: 6px 0 0;
+  max-width: 62ch;
+  color: var(--color-muted);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.composition-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 18px;
+  margin: 0;
+}
+
+.composition-stats div {
+  text-align: right;
+}
+
+.composition-stats dt {
+  color: var(--color-subtle);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+
+.composition-stats dd {
+  margin: 2px 0 0;
+  color: var(--color-heading);
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.composition-qualities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 16px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.composition-qualities li {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  border: 1px solid var(--color-border-soft);
+  border-radius: 999px;
+  background: var(--color-surface-muted);
+  padding: 4px 11px;
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.composition-qualities strong {
+  color: var(--map-accent);
+}
+
+/* 成分比較チャート（pH×成分総計 散布図） */
+:root {
+  --quality-simple: #7f8c99;
+  --quality-chloride: #d2544f;
+  --quality-bicarbonate: #3f9f9f;
+  --quality-sulfate: #c2a02a;
+  --quality-sulfur: #8e6bbf;
+  --quality-iron: #b5651d;
+  --quality-other: #9aa0a8;
+}
+
+html[data-theme="dark"] {
+  --quality-simple: #97a4b1;
+  --quality-chloride: #e8726d;
+  --quality-bicarbonate: #55bcbc;
+  --quality-sulfate: #d8ba4a;
+  --quality-sulfur: #a98adb;
+  --quality-iron: #cf8241;
+  --quality-other: #8b929b;
+}
+
+.composition-charts {
+  display: grid;
+  gap: 18px;
+  margin-top: 20px;
+}
+
+.composition-chart {
+  margin: 0;
+  border: 1px solid var(--color-border-soft);
+  border-radius: 10px;
+  background: var(--color-surface);
+  padding: 14px;
+}
+
+.composition-chart figcaption {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 10px;
+  align-items: baseline;
+}
+
+.composition-chart figcaption strong {
+  color: var(--color-heading);
+  font-size: 14px;
+}
+
+.composition-chart figcaption span {
+  color: var(--color-subtle);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.scatter-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  margin: 10px 0 0;
+  padding: 0;
+  color: var(--color-muted);
+  font-size: 11px;
+  list-style: none;
+}
+
+.scatter-legend li {
+  display: inline-flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.scatter-swatch {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+
+.scatter-swatch.quality-simple { background: var(--quality-simple); }
+.scatter-swatch.quality-chloride { background: var(--quality-chloride); }
+.scatter-swatch.quality-bicarbonate { background: var(--quality-bicarbonate); }
+.scatter-swatch.quality-sulfate { background: var(--quality-sulfate); }
+.scatter-swatch.quality-sulfur { background: var(--quality-sulfur); }
+.scatter-swatch.quality-iron { background: var(--quality-iron); }
+.scatter-swatch.quality-other { background: var(--quality-other); }
+
+.scatter-wrap {
+  overflow-x: auto;
+  margin-top: 12px;
+}
+
+.scatter-chart {
+  display: block;
+  width: 100%;
+  min-width: 520px;
+  height: auto;
+}
+
+.scatter-grid {
+  stroke: var(--color-border-soft);
+  stroke-width: 1;
+}
+
+.scatter-tick,
+.scatter-axis {
+  fill: var(--color-subtle);
+  font-size: 11px;
+}
+
+.scatter-label {
+  fill: var(--color-muted);
+  font-size: 11px;
+}
+
+.scatter-dot {
+  stroke: var(--color-surface);
+  stroke-width: 1.5;
+}
+
+.scatter-dot.quality-simple { fill: var(--quality-simple); }
+.scatter-dot.quality-chloride { fill: var(--quality-chloride); }
+.scatter-dot.quality-bicarbonate { fill: var(--quality-bicarbonate); }
+.scatter-dot.quality-sulfate { fill: var(--quality-sulfate); }
+.scatter-dot.quality-sulfur { fill: var(--quality-sulfur); }
+.scatter-dot.quality-iron { fill: var(--quality-iron); }
+.scatter-dot.quality-other { fill: var(--quality-other); }
+
+.composition-items {
+  display: grid;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.composition-item {
+  border: 1px solid var(--color-border-soft);
+  border-radius: 10px;
+  background: var(--color-surface);
+  overflow: hidden;
+}
+
+.composition-item[open] {
+  border-color: var(--color-border);
+}
+
+.composition-item > summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.composition-item > summary::-webkit-details-marker {
+  display: none;
+}
+
+.composition-item > summary:hover {
+  background: var(--color-surface-soft);
+}
+
+.composition-item-head {
+  min-width: 0;
+}
+
+.composition-item-head h3 {
+  margin: 0;
+  color: var(--color-heading);
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.composition-quality {
+  margin: 3px 0 0;
+  color: var(--map-accent);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.composition-quality-class {
+  margin: 2px 0 0;
+  color: var(--color-subtle);
+  font-size: 11px;
+}
+
+.composition-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.composition-badges li {
+  border-radius: 6px;
+  background: var(--color-surface-muted);
+  padding: 3px 8px;
+  color: var(--color-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.composition-body {
+  border-top: 1px solid var(--color-border-soft);
+  padding: 14px;
+}
+
+.composition-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px 18px;
+  margin: 0;
+}
+
+.composition-meta dt {
+  color: var(--color-subtle);
+  font-size: 11px;
+}
+
+.composition-meta dd {
+  margin: 2px 0 0;
+  color: var(--color-text);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.composition-treatment {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.composition-treatment li {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  flex-wrap: wrap;
+  border: 1px solid var(--color-border-soft);
+  border-radius: 8px;
+  padding: 5px 10px;
+  font-size: 11px;
+}
+
+.composition-treatment li > span {
+  color: var(--color-subtle);
+}
+
+.composition-treatment li > strong {
+  font-size: 12px;
+}
+
+.composition-treatment li.is-applied > strong {
+  color: var(--map-accent);
+}
+
+.composition-treatment li.is-none > strong {
+  color: var(--color-muted);
+}
+
+.composition-treatment li > em {
+  flex-basis: 100%;
+  color: var(--color-subtle);
+  font-style: normal;
+  line-height: 1.45;
+}
+
+.composition-tables {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.composition-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.composition-table caption {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-border-soft);
+  padding-bottom: 5px;
+  color: var(--color-heading);
+  font-size: 12px;
+  font-weight: 700;
+  text-align: left;
+}
+
+.composition-table caption span {
+  color: var(--color-subtle);
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+}
+
+.composition-table th {
+  padding: 4px 6px 4px 0;
+  color: var(--color-muted);
+  font-weight: 400;
+  text-align: left;
+}
+
+.composition-table td {
+  padding: 4px 0;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.composition-symbol {
+  margin-left: 5px;
+  color: var(--color-subtle);
+  font-size: 10px;
+}
+
+.composition-symptoms {
+  margin-top: 16px;
+}
+
+.composition-symptoms p {
+  margin: 6px 0 0;
+  color: var(--color-text);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.composition-symptom-label {
+  display: inline-block;
+  margin-right: 8px;
+  border-radius: 4px;
+  background: var(--color-surface-muted);
+  padding: 1px 6px;
+  color: var(--color-muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.composition-symptom-label.is-warn {
+  color: #b3541e;
+}
+
+html[data-theme="dark"] .composition-symptom-label.is-warn {
+  color: #ff9c6b;
+}
+
+.composition-notes,
+.composition-source {
+  margin: 14px 0 0;
+  color: var(--color-subtle);
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.composition-source {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+}
+
+.composition-confidence {
+  color: #b3541e;
+}
+
+html[data-theme="dark"] .composition-confidence {
+  color: #ff9c6b;
 }
 
 @media (max-width: 600px) {
@@ -1668,5 +2153,23 @@ body.photo-lightbox-open {
 
   .checkin-item h3 {
     font-size: 16px;
+  }
+
+  .composition-header {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .composition-stats div {
+    text-align: left;
+  }
+
+  .composition-item > summary {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .composition-tables {
+    grid-template-columns: 1fr;
   }
 }

--- a/scripts/fetch_foursquare_checkins.py
+++ b/scripts/fetch_foursquare_checkins.py
@@ -276,7 +276,18 @@ def photo_display_size():
 
 
 def photos_per_place_limit():
-    return max(1, int(os.environ.get('FOURSQUARE_CHECKIN_PHOTOS_PER_PLACE', '5')))
+    """1施設あたりに残す写真の枚数。既定は無制限（None）。
+
+    枚数を絞ると古い写真が押し出され、成分表を撮った写真が
+    onsen_places.json から消えて解析対象から漏れる。制限したいときだけ
+    FOURSQUARE_CHECKIN_PHOTOS_PER_PLACE に1以上を設定する。
+    """
+    raw = os.environ.get('FOURSQUARE_CHECKIN_PHOTOS_PER_PLACE', '')
+    try:
+        limit = int(raw)
+    except ValueError:
+        return None
+    return limit if limit > 0 else None
 
 
 def photo_url_from_item(photo, size=None):
@@ -345,7 +356,7 @@ def update_user_comment(place, shout, is_latest):
 
 
 def merge_photo_urls(existing, new_urls, limit, prepend=False):
-    """URL の重複を除き、施設ごとの上限枚数までまとめる"""
+    """URL の重複を除いてまとめる（limit が None なら枚数制限なし）"""
     ordered = (new_urls + existing) if prepend else (existing + new_urls)
     merged = []
     seen = set()
@@ -355,7 +366,7 @@ def merge_photo_urls(existing, new_urls, limit, prepend=False):
             continue
         seen.add(url)
         merged.append(url)
-        if len(merged) >= limit:
+        if limit is not None and len(merged) >= limit:
             break
 
     return merged
@@ -421,7 +432,7 @@ def build_places_from_checkins(checkins, category_ids, onsen_only=False):
             "lng": lng,
             "address": format_address(location),
             "foursquare_url": venue.get('canonicalUrl') or f"https://foursquare.com/v/{venue_id}",
-            "photos": checkin_photos[:photo_limit],
+            "photos": checkin_photos[:photo_limit] if photo_limit else list(checkin_photos),
             "categories": [
                 category.get('name')
                 for category in venue.get('categories', [])

--- a/scripts/merge_onsen_composition.py
+++ b/scripts/merge_onsen_composition.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Claude Code が書き起こした成分表データを astro/data/onsen_composition.json に反映する。
+
+prepare_onsen_composition.py が用意した .cache/onsen_photos/manifest.json と、
+そこにある写真を読んで書き起こした .cache/onsen_photos/extracted.json を突き合わせ、
+
+  * extracted.json に出てくる写真 → 施設ごとの成分データとして記録
+  * manifest にあるのに extracted.json に出てこない写真 → 成分表ではなかった写真として記録
+
+の2つに仕分けして保存する。どちらも「解析済み」として扱われるので、次回の
+prepare_onsen_composition.py は残りの写真だけを対象にする。
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import date
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ASTRO_DIR = os.path.join(BASE_DIR, 'astro')
+CACHE_DIR = os.path.join(BASE_DIR, '.cache', 'onsen_photos')
+MANIFEST_JSON = os.path.join(CACHE_DIR, 'manifest.json')
+EXTRACTED_JSON = os.path.join(CACHE_DIR, 'extracted.json')
+ONSEN_JSON = os.path.join(ASTRO_DIR, 'data', 'onsen_places.json')
+OUTPUT_JSON = os.path.join(ASTRO_DIR, 'data', 'onsen_composition.json')
+
+# 施設ごとに保持するキーの並び（出力の見やすさのため固定）
+FIELD_ORDER = [
+    "fsq_id",
+    "name",
+    "address",
+    "checkin_date",
+    "confidence",
+    "spring_name",
+    "spring_quality",
+    "spring_quality_class",
+    "source_temp_c",
+    "use_temp_c",
+    "ph",
+    "ph_lab",
+    "yield_l_min",
+    "evaporation_residue_mg_kg",
+    "dissolved_solids_mg_kg",
+    "total_ingredients_mg_kg",
+    "cations",
+    "cations_total_mg_kg",
+    "anions",
+    "anions_total_mg_kg",
+    "undissociated",
+    "undissociated_total_mg_kg",
+    "dissolved_gas",
+    "dissolved_gas_total_mg_kg",
+    "treatment",
+    "indications",
+    "contraindications",
+    "analyzed_on",
+    "analyzer",
+    "analyzer_registration",
+    "notes",
+    "source_photos",
+]
+
+
+def load_json(path, fallback=None):
+    if not os.path.exists(path):
+        return fallback
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def photo_lookup(manifest):
+    return {photo['index']: photo for photo in manifest.get('photos', [])}
+
+
+def order_fields(entry):
+    ordered = {key: entry[key] for key in FIELD_ORDER if key in entry}
+    for key, value in entry.items():
+        if key not in ordered:
+            ordered[key] = value
+    return ordered
+
+
+def build_entries(extracted, photos_by_index):
+    """extracted.json の各エントリを、写真から施設情報を補って組み立てる。"""
+    entries = []
+    used_photo_urls = set()
+
+    for raw in extracted.get('places', []):
+        indexes = raw.get('photo_indexes') or []
+        photos = [photos_by_index[i] for i in indexes if i in photos_by_index]
+        missing = [i for i in indexes if i not in photos_by_index]
+        if missing:
+            print(f"[Warn] manifest に無い photo_index: {missing}", file=sys.stderr)
+        if not photos:
+            print(f"[Warn] 写真を解決できないエントリをスキップ: {indexes}", file=sys.stderr)
+            continue
+
+        entry = {key: value for key, value in raw.items() if key != 'photo_indexes'}
+        entry['fsq_id'] = photos[0].get('fsq_id', '')
+        entry['name'] = photos[0].get('place_name', '')
+        entry['address'] = photos[0].get('address', '')
+        entry['checkin_date'] = photos[0].get('date', '')
+        entry['source_photos'] = [photo['photo_url'] for photo in photos]
+        used_photo_urls.update(entry['source_photos'])
+
+        entries.append(order_fields(entry))
+
+    return entries, used_photo_urls
+
+
+def merge_places(existing, incoming):
+    """fsq_id をキーに既存データへマージする。
+
+    既存エントリがある場合は差し替えではなく項目単位でマージする。再訪して掲示の
+    一部だけ読み直したときに、前回読み取った成分値まで失われないようにするため。
+    項目を消したいときは astro/data/onsen_composition.json を直接編集する。
+    """
+    by_id = {entry.get('fsq_id'): entry for entry in existing}
+
+    for entry in incoming:
+        fsq_id = entry.get('fsq_id')
+        current = by_id.get(fsq_id)
+        if current:
+            photos = current.get('source_photos', []) + [
+                url for url in entry.get('source_photos', [])
+                if url not in current.get('source_photos', [])
+            ]
+            entry = {**current, **entry, 'source_photos': photos}
+        by_id[fsq_id] = order_fields(entry)
+
+    return list(by_id.values())
+
+
+def sort_key(entry, order_by_fsq):
+    return order_by_fsq.get(entry.get('fsq_id'), 10**6)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="成分表の書き起こしをデータJSONに反映する")
+    parser.add_argument(
+        '--extracted',
+        default=EXTRACTED_JSON,
+        help=f"書き起こしJSONのパス（既定: {EXTRACTED_JSON}）",
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help="書き込まずに結果だけ表示する",
+    )
+    args = parser.parse_args()
+
+    manifest = load_json(MANIFEST_JSON)
+    if not manifest:
+        print(f"[Error] {MANIFEST_JSON} がありません。先に prepare_onsen_composition.py を実行してください。", file=sys.stderr)
+        sys.exit(1)
+
+    extracted = load_json(args.extracted)
+    if not extracted:
+        print(f"[Error] {args.extracted} がありません。", file=sys.stderr)
+        sys.exit(1)
+
+    photos_by_index = photo_lookup(manifest)
+    entries, used_photo_urls = build_entries(extracted, photos_by_index)
+
+    current = load_json(OUTPUT_JSON, {}) or {}
+    places = merge_places(current.get('places', []), entries)
+
+    not_composition = list(current.get('not_composition_photos') or [])
+    for photo in manifest.get('photos', []):
+        url = photo['photo_url']
+        if url in used_photo_urls or url in not_composition:
+            continue
+        not_composition.append(url)
+
+    # 温泉一覧（新しいチェックイン順）に合わせて並べる
+    onsen_places = load_json(ONSEN_JSON, []) or []
+    order_by_fsq = {
+        place.get('fsq_id'): index for index, place in enumerate(onsen_places)
+    }
+    places.sort(key=lambda entry: sort_key(entry, order_by_fsq))
+
+    payload = {
+        "generated_on": date.today().isoformat(),
+        "stats": {
+            "places": len(places),
+            "composition_photos": sum(len(entry.get('source_photos') or []) for entry in places),
+            "not_composition_photos": len(not_composition),
+        },
+        "places": places,
+        "not_composition_photos": not_composition,
+    }
+
+    print("=== 成分表データを更新 ===")
+    print(f"成分表のある施設: {payload['stats']['places']}件")
+    print(f"成分表の写真: {payload['stats']['composition_photos']}枚")
+    print(f"成分表ではなかった写真: {payload['stats']['not_composition_photos']}枚")
+
+    if args.dry_run:
+        print("--dry-run のため書き込みませんでした。")
+        return
+
+    with open(OUTPUT_JSON, 'w', encoding='utf-8') as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+        f.write('\n')
+
+    print(f"書き出し先: {OUTPUT_JSON}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_onsen_composition.py
+++ b/scripts/prepare_onsen_composition.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""温泉チェックイン写真を成分表解析用にダウンロードして並べる。
+
+Foursquare のチェックイン写真には温泉分析書（成分表）の掲示を撮ったものが混ざっている。
+このスクリプトは解析そのものはせず、Claude Code の対話セッションで読ませるための
+素材だけを用意する:
+
+  1. astro/data/onsen_places.json の写真URLを original 解像度に変換してダウンロード
+  2. astro/data/onsen_composition.json に記録済みの写真はスキップ（増分実行）
+  3. 一覧レビュー用のコンタクトシート（番号入りタイル画像）を生成
+
+出力はすべて .cache/onsen_photos/ 以下（gitignore 済み）。
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+
+import requests
+from PIL import Image, ImageDraw, ImageFont
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ASTRO_DIR = os.path.join(BASE_DIR, 'astro')
+ONSEN_JSON = os.path.join(ASTRO_DIR, 'data', 'onsen_places.json')
+COMPOSITION_JSON = os.path.join(ASTRO_DIR, 'data', 'onsen_composition.json')
+CACHE_DIR = os.path.join(BASE_DIR, '.cache', 'onsen_photos')
+PHOTO_DIR = os.path.join(CACHE_DIR, 'photos')
+SHEET_DIR = os.path.join(CACHE_DIR, 'sheets')
+MANIFEST_JSON = os.path.join(CACHE_DIR, 'manifest.json')
+
+# コンタクトシートの体裁
+SHEET_COLUMNS = 4
+SHEET_ROWS = 5
+CELL_WIDTH = 460
+CELL_HEIGHT = 345
+LABEL_HEIGHT = 34
+
+
+def original_url(url):
+    """Foursquare のリサイズ済みURLをオリジナル解像度に変換する。
+
+    例: .../img/general/500x300/41463109_xxx.jpg -> .../img/general/original/41463109_xxx.jpg
+    """
+    for size in ('/500x300/', '/300x300/', '/original/'):
+        if size in url:
+            return url.replace(size, '/original/')
+
+    parts = url.split('/img/general/')
+    if len(parts) == 2:
+        tail = parts[1].split('/', 1)
+        if len(tail) == 2:
+            return f"{parts[0]}/img/general/original/{tail[1]}"
+
+    return url
+
+
+def photo_key(url):
+    return hashlib.sha1(url.encode('utf-8')).hexdigest()[:16]
+
+
+def load_json(path, fallback):
+    if not os.path.exists(path):
+        return fallback
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def analyzed_photo_urls():
+    """解析済み（成分表だった／成分表でなかった、どちらも）の写真URL集合。"""
+    data = load_json(COMPOSITION_JSON, None)
+    if not data:
+        return set()
+
+    analyzed = set(data.get('not_composition_photos') or [])
+    for entry in data.get('places') or []:
+        for url in entry.get('source_photos') or []:
+            analyzed.add(url)
+    return analyzed
+
+
+def collect_targets(places, skip_urls):
+    targets = []
+    for place in places:
+        for url in place.get('photos') or []:
+            if url in skip_urls:
+                continue
+            targets.append({
+                "place_name": place.get('name', ''),
+                "fsq_id": place.get('fsq_id', ''),
+                "date": place.get('date', ''),
+                "address": place.get('address', ''),
+                "photo_url": url,
+                "original_url": original_url(url),
+            })
+    return targets
+
+
+def download(target, session, force=False):
+    key = photo_key(target['photo_url'])
+    path = os.path.join(PHOTO_DIR, f"{key}.jpg")
+    target['key'] = key
+    target['file'] = path
+
+    if os.path.exists(path) and os.path.getsize(path) > 0 and not force:
+        target['downloaded'] = False
+        return True
+
+    try:
+        response = session.get(target['original_url'], timeout=30)
+    except requests.RequestException as exc:
+        print(f"[Warn] ダウンロード失敗 {target['original_url']}: {exc}", file=sys.stderr)
+        return False
+
+    if response.status_code != 200 or not response.content:
+        print(
+            f"[Warn] ダウンロード失敗 HTTP {response.status_code}: {target['original_url']}",
+            file=sys.stderr,
+        )
+        return False
+
+    with open(path, 'wb') as f:
+        f.write(response.content)
+    target['downloaded'] = True
+    return True
+
+
+def label_font(size):
+    for candidate in (
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    ):
+        if os.path.exists(candidate):
+            return ImageFont.truetype(candidate, size)
+    return ImageFont.load_default(size=size)
+
+
+def build_contact_sheets(targets):
+    """番号を焼き込んだタイル画像を作る。番号は manifest の index と一致する。"""
+    per_sheet = SHEET_COLUMNS * SHEET_ROWS
+    font = label_font(24)
+    sheets = []
+
+    for sheet_no, start in enumerate(range(0, len(targets), per_sheet), start=1):
+        chunk = targets[start:start + per_sheet]
+        rows = (len(chunk) + SHEET_COLUMNS - 1) // SHEET_COLUMNS
+        sheet = Image.new(
+            'RGB',
+            (SHEET_COLUMNS * CELL_WIDTH, rows * (CELL_HEIGHT + LABEL_HEIGHT)),
+            (24, 24, 27),
+        )
+        draw = ImageDraw.Draw(sheet)
+
+        for offset, target in enumerate(chunk):
+            col = offset % SHEET_COLUMNS
+            row = offset // SHEET_COLUMNS
+            x = col * CELL_WIDTH
+            y = row * (CELL_HEIGHT + LABEL_HEIGHT)
+
+            try:
+                with Image.open(target['file']) as img:
+                    thumb = img.convert('RGB')
+                    thumb.thumbnail((CELL_WIDTH - 8, CELL_HEIGHT - 8))
+                    sheet.paste(
+                        thumb,
+                        (x + (CELL_WIDTH - thumb.width) // 2, y + (CELL_HEIGHT - thumb.height) // 2),
+                    )
+            except OSError as exc:
+                print(f"[Warn] 画像を開けません {target['file']}: {exc}", file=sys.stderr)
+
+            draw.text(
+                (x + 10, y + CELL_HEIGHT + 4),
+                f"#{target['index']}",
+                fill=(255, 214, 102),
+                font=font,
+            )
+
+        path = os.path.join(SHEET_DIR, f"sheet-{sheet_no:02d}.jpg")
+        sheet.save(path, quality=88)
+        sheets.append(path)
+        print(f"コンタクトシート: {path} (#{chunk[0]['index']}〜#{chunk[-1]['index']})")
+
+    return sheets
+
+
+def main():
+    parser = argparse.ArgumentParser(description="温泉写真を成分表解析用に準備する")
+    parser.add_argument(
+        '--all',
+        action='store_true',
+        help="解析済みの写真も含めて全件を対象にする（既定は未解析のみ）",
+    )
+    parser.add_argument(
+        '--force-download',
+        action='store_true',
+        help="キャッシュ済みの画像も再ダウンロードする",
+    )
+    parser.add_argument(
+        '--limit',
+        type=int,
+        default=0,
+        help="対象写真の上限枚数（0で無制限）",
+    )
+    args = parser.parse_args()
+
+    os.makedirs(PHOTO_DIR, exist_ok=True)
+    os.makedirs(SHEET_DIR, exist_ok=True)
+
+    places = load_json(ONSEN_JSON, [])
+    skip_urls = set() if args.all else analyzed_photo_urls()
+    targets = collect_targets(places, skip_urls)
+
+    total_photos = sum(len(place.get('photos') or []) for place in places)
+    print("=== 温泉成分表の解析素材を準備 ===")
+    print(f"温泉施設: {len(places)}件 / 写真: {total_photos}枚")
+    print(f"解析済み写真: {len(skip_urls)}枚")
+    print(f"今回の対象: {len(targets)}枚")
+
+    if args.limit:
+        targets = targets[:args.limit]
+        print(f"--limit により {len(targets)}枚に制限")
+
+    if not targets:
+        print("新しく解析する写真はありません。")
+        return
+
+    session = requests.Session()
+    session.headers.update({"User-Agent": "peipeipe.net onsen composition prep"})
+
+    downloaded = []
+    for target in targets:
+        if download(target, session, force=args.force_download):
+            downloaded.append(target)
+
+    for index, target in enumerate(downloaded, start=1):
+        target['index'] = index
+
+    new_files = sum(1 for target in downloaded if target.get('downloaded'))
+    print(f"取得成功: {len(downloaded)}枚（新規ダウンロード {new_files}枚）")
+
+    build_contact_sheets(downloaded)
+
+    manifest = {
+        "generated_from": os.path.relpath(ONSEN_JSON, BASE_DIR),
+        "photo_count": len(downloaded),
+        "photos": downloaded,
+    }
+    with open(MANIFEST_JSON, 'w', encoding='utf-8') as f:
+        json.dump(manifest, f, ensure_ascii=False, indent=2)
+        f.write('\n')
+
+    print(f"マニフェスト: {MANIFEST_JSON}")
+    print(f"画像キャッシュ: {PHOTO_DIR}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Onsen check-in photos increasingly include the posted 温泉分析書 / 温泉成分等掲示表. This turns them into structured data and surfaces it on `/onsen`.

Includes the side-panel fix from `fix-side-panel-horizontal-scroll`, which was never opened as a PR — the new 泉質 badge sits inside `.checkin-item-body` and relies on its `min-width: 0` to keep long spring names from widening the card.

## Commits

- **Stop long titles from widening side-panel cards** — `min-width: 0` on the activity/mountain/onsen card bodies so the existing ellipsis wins over `nowrap` titles.
- **Keep every check-in photo per venue** — the 5-photo cap let newer check-ins push older photos out of `onsen_places.json`, which would silently drop analysis sheets that had not been transcribed yet. Now unlimited by default; `FOURSQUARE_CHECKIN_PHOTOS_PER_PLACE` still caps it when set.
- **Add hot spring composition sheets read from check-in photos** — the workflow, the data, and the rendering.

## How the batch works

No OCR service and no API key. The reading step happens in a Claude Code session via `/onsen-composition`; the scripts only handle either side of it.

```sh
python3 scripts/prepare_onsen_composition.py   # download unanalyzed photos + build contact sheets
# → Claude reads the images and writes .cache/onsen_photos/extracted.json
python3 scripts/merge_onsen_composition.py     # fold it into astro/data/onsen_composition.json
```

Photos are fetched at `original` resolution — Foursquare's `500x300` variant is too small to read. Photos that turn out not to be analysis sheets are recorded as well, which is what makes the batch incremental: 105 photos yielded 14 sheets across 13 venues, and a second run finds nothing to do. Re-reads merge per field on `fsq_id`, so correcting one value does not discard the rest.

## Verification

- Transcribed figures were checked against the mval percentages the sheets print themselves — recomputing them from the mg/kg values reproduces ゆーぷる木崎湖's Cl 59.32 / HCO₃ 31.77 / SO₄ 3.44 to within rounding.
- Entries carry a `confidence` field where the photo was too small to be certain (1 low, 1 medium); unreadable figures are omitted rather than guessed.
- Scatter plot: all 12 plotted venues fall inside the drawing area and no two labels collide.
- `npm run build` (431 pages) and `npm run check:legacy-slugs` pass.

## On the page

A 泉質 badge on each check-in card — also searchable, and re-rendered client-side from `onsen-data.json` — plus a 成分表 section below the map with per-venue ion tables, 加水/加温/循環/消毒, 適応症, and a pH × total-dissolved scatter plot coloured by spring type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmsBmpqyy5pn1nhtx9HXeN