### PR TITLE
Fix mobile horizontal scroll and long scroll to onsen composition

### DIFF
--- a/astro/src/pages/onsen.astro
+++ b/astro/src/pages/onsen.astro
@@ -130,10 +130,10 @@ const scatterGroups = [...new Map(plotted.map((point) => [point.group.key, point
           <strong>{stats.withPhotos.toLocaleString()}</strong>
           <span>Photos</span>
         </div>
-        <div>
+        <a href="#composition">
           <strong>{compositionStats.count.toLocaleString()}</strong>
           <span>成分表</span>
-        </div>
+        </a>
         <div>
           <strong>{stats.latest?.date || ""}</strong>
           <span>Latest</span>
@@ -266,6 +266,7 @@ const scatterGroups = [...new Map(plotted.map((point) => [point.group.key, point
           <figcaption>
             <strong>pH と成分総計</strong>
             <span>右へ行くほどアルカリ性、上へ行くほど濃い温泉です（縦軸は対数）。</span>
+            <span class="scatter-hint">図は横にスワイプできます。</span>
           </figcaption>
 
           <ul class="scatter-legend">

--- a/astro/src/styles/global.css
+++ b/astro/src/styles/global.css
@@ -954,11 +954,25 @@ body.photo-lightbox-open {
   gap: 8px;
 }
 
-.map-app-stats div {
+.map-app-stats > * {
   border: 1px solid var(--color-border);
   border-radius: 8px;
   background: var(--color-surface-soft);
   padding: 10px 12px;
+}
+
+/* 成分表タイルはページ下部の一覧へのジャンプリンクを兼ねる */
+.map-app-stats a {
+  display: block;
+  color: inherit;
+}
+
+.map-app-stats a:hover {
+  border-color: var(--map-accent);
+}
+
+.map-app-stats a span::after {
+  content: " ↓";
 }
 
 .map-app-stats strong {
@@ -1551,6 +1565,7 @@ body.photo-lightbox-open {
   margin-top: 28px;
   border-top: 1px solid var(--color-border-soft);
   padding-top: 22px;
+  scroll-margin-top: 12px;
 }
 
 .composition-header {
@@ -1646,11 +1661,16 @@ html[data-theme="dark"] {
 
 .composition-charts {
   display: grid;
+  /* 既定の auto トラックだと図の min-content（＝SVG の min-width）まで広がって
+     ページ全体が横スクロールしてしまうので、列幅をコンテナ幅で頭打ちにする */
+  grid-template-columns: minmax(0, 1fr);
   gap: 18px;
   margin-top: 20px;
 }
 
 .composition-chart {
+  /* グリッドアイテムの自動最小サイズも同じ理由で潰しておく */
+  min-width: 0;
   margin: 0;
   border: 1px solid var(--color-border-soft);
   border-radius: 10px;
@@ -1674,6 +1694,18 @@ html[data-theme="dark"] {
   color: var(--color-subtle);
   font-size: 12px;
   line-height: 1.5;
+}
+
+/* 図が実際に収まらなくなる幅（.scatter-chart の min-width + 余白）でだけ出す */
+.scatter-hint {
+  display: none;
+}
+
+@media (max-width: 569px) {
+  .composition-chart figcaption .scatter-hint {
+    display: inline;
+    color: var(--map-accent);
+  }
 }
 
 .scatter-legend {
@@ -1710,6 +1742,8 @@ html[data-theme="dark"] {
 
 .scatter-wrap {
   overflow-x: auto;
+  /* 図をスワイプしたときにページ側の横スクロールへ連鎖させない */
+  overscroll-behavior-x: contain;
   margin-top: 12px;
 }
 
@@ -2132,7 +2166,7 @@ html[data-theme="dark"] .composition-confidence {
   }
 
   .map-side-panel {
-    max-height: none;
+    max-height: 70vh;
   }
 
   .activity-list.compact {
@@ -2141,10 +2175,6 @@ html[data-theme="dark"] .composition-confidence {
 
   .mountain-list.compact {
     max-height: 480px;
-  }
-
-  .checkin-list.compact {
-    max-height: none;
   }
 
   .checkin-item-photo {


### PR DESCRIPTION
## 横スクロール

`.scatter-chart` の `min-width: 520px` は `.scatter-wrap` の `overflow-x: auto` で内側に閉じ込める設計だったが、

- `.composition-charts` の暗黙の `auto` グリッドトラックが図の min-content（520px + 余白 = 550px）まで伸びる
- グリッドアイテム `.composition-chart` の自動最小サイズも min-content

の2点でトラックがビューポートを突き抜け、`/onsen` 全体が横スクロールしていた（390px 幅で `scrollWidth=560`）。トラックとアイテムの両方を頭打ちにして、スクロールを図自身のボックス内に戻す。図が収まらない幅ではスワイプできることを明示する。

## 成分表までのスクロール量

モバイルでは `.map-side-panel` が `max-height: none` で温泉一覧123件がフル展開され、ページ高さ 27,729px・成分表セクションが offsetTop 25,147px にあった。デスクトップと同じくパネル内スクロールに戻し、ヘッダーの「成分表」タイルを `#composition` へのジャンプリンクにする。

## 確認

headless Chromium で 320 / 375 / 390 / 430 / 569 / 600 / 768 / 1024 / 1280px を実測。

- 全幅で `scrollWidth == clientWidth`（ページ横スクロールなし）
- 390px でページ高さ 27,729px → 4,531px、成分表 offsetTop 25,147px → 1,871px
- `/activity`, `/mountains`, `/places` も横溢れなし（`.map-app-stats div` → `.map-app-stats > *` と `.map-side-panel` のモバイル max-height が共通のため確認）
- `npm run build` / `npm run check:legacy-slugs` ともに通過（0 issue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7Nz4XFigjPenP5hx1bVY1