### PR TITLE
Retry OSM peak update pushes

### DIFF
--- a/.github/workflows/update-osm-peaks.yml
+++ b/.github/workflows/update-osm-peaks.yml
@@ -55,8 +55,17 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "Update OSM peaks"
-            git push
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            for attempt in 1 2 3; do
+              git pull --rebase --autostash origin "$GITHUB_REF_NAME"
+              if git push; then
+                echo "changed=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "Push failed; retrying after remote update (attempt $attempt/3)"
+              sleep $((attempt * 5))
+            done
+            echo "Failed to push OSM peak updates after 3 attempts"
+            exit 1
           fi
 
       - name: Trigger Cloudflare Pages deploy


### PR DESCRIPTION
## What changed

- Rebase the generated OSM peak update commit onto the latest `master` before pushing.
- Retry the push up to three times when another workflow updates the branch concurrently.
- Fail with a clear message after the retry limit.

## Why

The scheduled OSM peak update run failed after successfully generating its data because `master` advanced during the run. The final push was rejected as a non-fast-forward update.

## Impact

Scheduled OSM peak refreshes can tolerate concurrent updates to `master` without losing generated data or requiring a manual rerun in the common race case.

## Validation

- `git diff --check`
- Parsed `.github/workflows/update-osm-peaks.yml` with PyYAML
